### PR TITLE
Reading primitives unsafe (natively through ByteBuffer API)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 # Please keep the list sorted.
 
+Alexander Sergeev <alex75.95@yandex.com>
 Andrey Korzinev <ya-goodfella@yandex.com>
 Svyatoslav Demidov <demidov.svyatoslav@yandex.com>
 Vadim Tsesko <incubos@yandex.com>

--- a/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
@@ -50,4 +50,43 @@ public interface DocumentProvider {
             int document,
             @NotNull
             String fieldName);
+
+    /**
+     * Get {@code document} document {@code fieldName} field value as long.
+     *
+     * The field must be sortable
+     *
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#STORED
+     * @param document document index
+     * @param fieldName field name
+     * @return document field value as long
+     */
+
+    @NotNull
+    long getLongValue(
+            int document,
+            @NotNull
+            String fieldName);
+
+    /**
+     * Get {@code document} document {@code fieldName} field value as int.
+     *
+     * The field must be sortable
+     *
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#STORED
+     * @param document document index
+     * @param fieldName field name
+     * @return document field value as int
+     */
+
+    @NotNull
+    int getIntValue(
+            int document,
+            @NotNull
+            String fieldName);
+
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
@@ -86,7 +86,7 @@ public interface DocumentProvider {
             String fieldName);
 
     /**
-     * Get {@code document} document @{code fieldName} field value as short.
+     * Get {@code document} document {@code fieldName} field value as short.
      *
      * The field must be sortable, stored or full.
      *

--- a/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
@@ -36,7 +36,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value.
      *
-     * The field must be sortable.
+     * The field must be sortable, stored or full
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -54,7 +54,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value as long.
      *
-     * The field must be sortable
+     * The field must be sortable, stored or full
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -63,8 +63,6 @@ public interface DocumentProvider {
      * @param fieldName field name
      * @return document field value as long
      */
-
-    @NotNull
     long getLongValue(
             int document,
             @NotNull
@@ -73,7 +71,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value as int.
      *
-     * The field must be sortable
+     * The field must be sortable, stored or full
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -82,11 +80,41 @@ public interface DocumentProvider {
      * @param fieldName field name
      * @return document field value as int
      */
-
-    @NotNull
     int getIntValue(
             int document,
             @NotNull
             String fieldName);
 
+    /**
+     * Get {@code document} document @{code fieldName} field value as short.
+     *
+     * The field must be sortable, stored or full
+     *
+     * @param document document index
+     * @param fieldName field name
+     * @return document field value as short
+     */
+    short getShortValue(
+            int document,
+            @NotNull
+            String fieldName
+    );
+
+    /**
+     * Get {@code document} document {@code fieldName} field value as char.
+     *
+     * The field must be sortable, stored or full
+     *
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#STORED
+     * @param document document index
+     * @param fieldName field name
+     * @return document field value as char
+     */
+    char getCharValue(
+            int document,
+            @NotNull
+            String fieldName
+    );
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
@@ -36,7 +36,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value.
      *
-     * The field must be sortable, stored or full
+     * The field must be sortable, stored or full.
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -54,7 +54,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value as long.
      *
-     * The field must be sortable, stored or full
+     * The field must be sortable, stored or full.
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -71,7 +71,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value as int.
      *
-     * The field must be sortable, stored or full
+     * The field must be sortable, stored or full.
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
@@ -88,7 +88,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document @{code fieldName} field value as short.
      *
-     * The field must be sortable, stored or full
+     * The field must be sortable, stored or full.
      *
      * @param document document index
      * @param fieldName field name
@@ -103,7 +103,7 @@ public interface DocumentProvider {
     /**
      * Get {@code document} document {@code fieldName} field value as char.
      *
-     * The field must be sortable, stored or full
+     * The field must be sortable, stored or full.
      *
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
      * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL

--- a/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/DocumentProvider.java
@@ -117,4 +117,22 @@ public interface DocumentProvider {
             @NotNull
             String fieldName
     );
+
+    /**
+     * Get {@code document} document {@code fieldName} field value as byte.
+     *
+     * The field must be sortable, stored or full.
+     *
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#SORTABLE
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#FULL
+     * @see com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption#STORED
+     * @param document document index
+     * @param fieldName field name
+     * @return document field value as byte
+     */
+    byte getByteValue(
+            int document,
+            @NotNull
+            String fieldName
+    );
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
@@ -63,10 +63,10 @@ public interface StoredIndex extends Index {
     char getCharValue(int document);
 
     /**
-     * Get stored value as char by document ID
+     * Get stored value as byte by document ID
      *
      * @param document document ID
-     * @return stored value as char
+     * @return stored value as byte
      */
     byte getByteValue(int document);
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
@@ -61,4 +61,12 @@ public interface StoredIndex extends Index {
      * @return stored value as char
      */
     char getCharValue(int document);
+
+    /**
+     * Get stored value as char by document ID
+     *
+     * @param document document ID
+     * @return stored value as char
+     */
+    byte getByteValue(int document);
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
@@ -34,14 +34,28 @@ public interface StoredIndex extends Index {
      * Get stored value as long by document ID
      *
      * @param document document ID
-     * @return stored value
+     * @return stored value as long
      */
     long getLongValue(int document);
 
     /**
      * Get stored value as int by document ID
      * @param document document ID
-     * @return stored value
+     * @return stored value as int
      */
     int getIntValue(int document);
+
+    /**
+     * Get stored value as short by document ID
+     * @param document document ID
+     * @return stored value as short
+     */
+    short getShortValue(int document);
+
+    /**
+     * Get stored value as char by document ID
+     * @param document document ID
+     * @return stored value as char
+     */
+    char getCharValue(int document);
 }

--- a/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
@@ -40,6 +40,7 @@ public interface StoredIndex extends Index {
 
     /**
      * Get stored value as int by document ID
+     *
      * @param document document ID
      * @return stored value as int
      */
@@ -47,6 +48,7 @@ public interface StoredIndex extends Index {
 
     /**
      * Get stored value as short by document ID
+     *
      * @param document document ID
      * @return stored value as short
      */
@@ -54,6 +56,7 @@ public interface StoredIndex extends Index {
 
     /**
      * Get stored value as char by document ID
+     *
      * @param document document ID
      * @return stored value as char
      */

--- a/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/immutable/StoredIndex.java
@@ -29,4 +29,19 @@ public interface StoredIndex extends Index {
      */
     @NotNull
     Buffer getStoredValue(int document);
+
+    /**
+     * Get stored value as long by document ID
+     *
+     * @param document document ID
+     * @return stored value
+     */
+    long getLongValue(int document);
+
+    /**
+     * Get stored value as int by document ID
+     * @param document document ID
+     * @return stored value
+     */
+    int getIntValue(int document);
 }

--- a/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
+++ b/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
@@ -98,7 +98,7 @@ public abstract class AbstractDocumentBuilder
             final char value,
             @NotNull
             final IndexOption index) {
-        return withField(name, UnsignedByteArrays.from(value), index, LengthOption.FIXED);
+        return withField(name, UnsignedByteArrays.from(value), index, IndexType.FIXED_LENGTH);
     }
 
     @NotNull

--- a/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
+++ b/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
@@ -97,8 +97,7 @@ public abstract class AbstractDocumentBuilder
             final String name,
             final char value,
             @NotNull
-            final IndexOption index
-    ) {
+            final IndexOption index) {
         return withField(name, UnsignedByteArrays.from(value), index, LengthOption.FIXED);
     }
 

--- a/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
+++ b/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
@@ -85,8 +85,7 @@ public abstract class AbstractDocumentBuilder
     @Override
     public DocumentBuilder withField(
             @NotNull
-            final
-            String name,
+            final String name,
             final long value,
             @NotNull
             final IndexOption index) {
@@ -95,8 +94,7 @@ public abstract class AbstractDocumentBuilder
 
     public DocumentBuilder withField(
             @NotNull
-            final
-            String name,
+            final String name,
             final char value,
             @NotNull
             final IndexOption index

--- a/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
+++ b/core/src/main/java/com/yandex/yoctodb/mutable/AbstractDocumentBuilder.java
@@ -93,6 +93,17 @@ public abstract class AbstractDocumentBuilder
         return withField(name, UnsignedByteArrays.from(value), index, LengthOption.FIXED);
     }
 
+    public DocumentBuilder withField(
+            @NotNull
+            final
+            String name,
+            final char value,
+            @NotNull
+            final IndexOption index
+    ) {
+        return withField(name, UnsignedByteArrays.from(value), index, LengthOption.FIXED);
+    }
+
     @NotNull
     @Override
     public DocumentBuilder withField(

--- a/core/src/main/java/com/yandex/yoctodb/mutable/DocumentBuilder.java
+++ b/core/src/main/java/com/yandex/yoctodb/mutable/DocumentBuilder.java
@@ -116,6 +116,15 @@ public interface DocumentBuilder {
     DocumentBuilder withField(
             @NotNull
             String name,
+            char c,
+            @NotNull
+            IndexOption index
+    );
+
+    @NotNull
+    DocumentBuilder withField(
+            @NotNull
+            String name,
             @NotNull
             String value,
             @NotNull

--- a/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
@@ -82,6 +82,14 @@ public class UnsignedByteArrays {
         return from(Ints.toByteArray(i ^ Integer.MIN_VALUE));
     }
 
+    @NotNull
+    public static UnsignedByteArray from(final char c) {
+        final int ci = c ^ Character.MIN_VALUE;
+        assert Character.MIN_VALUE <= ci && ci <= Character.MAX_VALUE;
+
+        return from(Chars.toByteArray((char) ci));
+    }
+
     public static int toInt(
             @NotNull
             final UnsignedByteArray bytes) {

--- a/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
@@ -85,9 +85,7 @@ public class UnsignedByteArrays {
     @NotNull
     public static UnsignedByteArray from(final char c) {
         final int ci = c ^ Character.MIN_VALUE;
-        assert Character.MIN_VALUE <= ci && ci <= Character.MAX_VALUE;
-
-        return from(Chars.toByteArray((char) ci));
+        return from(Chars.toByteArray(Chars.checkedCast(ci)));
     }
 
     public static int toInt(

--- a/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
@@ -84,8 +84,7 @@ public class UnsignedByteArrays {
 
     @NotNull
     public static UnsignedByteArray from(final char c) {
-        final int ci = c ^ Character.MIN_VALUE;
-        return from(Chars.toByteArray(Chars.checkedCast(ci)));
+        return from(Chars.toByteArray(Chars.checkedCast(c)));
     }
 
     public static int toInt(

--- a/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/UnsignedByteArrays.java
@@ -84,7 +84,7 @@ public class UnsignedByteArrays {
 
     @NotNull
     public static UnsignedByteArray from(final char c) {
-        return from(Chars.toByteArray(Chars.checkedCast(c)));
+        return from(Chars.toByteArray(c));
     }
 
     public static int toInt(

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/Buffer.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/Buffer.java
@@ -120,6 +120,14 @@ public abstract class Buffer implements Comparable<Buffer> {
 
     public abstract long getLong(long index);
 
+    public abstract char getChar();
+
+    public abstract char getChar(long index);
+
+    public abstract short getShort();
+
+    public abstract short getShort(long index);
+
     public Buffer slice() {
         return slice(remaining());
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/ByteBufferWrapper.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/ByteBufferWrapper.java
@@ -118,6 +118,30 @@ public final class ByteBufferWrapper extends Buffer {
     }
 
     @Override
+    public char getChar() {
+        return delegate.getChar();
+    }
+
+    @Override
+    public char getChar(long index) {
+        assert index <= Integer.MAX_VALUE;
+
+        return delegate.getChar((int) index);
+    }
+
+    @Override
+    public short getShort() {
+        return delegate.getShort();
+    }
+
+    @Override
+    public short getShort(long index) {
+        assert index <= Integer.MAX_VALUE;
+
+        return delegate.getShort((int) index);
+    }
+
+    @Override
     public Buffer slice() {
         return Buffer.from(delegate.slice());
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
@@ -233,7 +233,7 @@ public final class FileChannelBuffer extends Buffer {
 
     @Override
     public char getChar() {
-        assert remaining()  >= Character.BYTES;
+        assert remaining() >= Character.BYTES;
 
         final ByteBuffer charBuf = charBufCache.get();
         try {
@@ -265,7 +265,7 @@ public final class FileChannelBuffer extends Buffer {
 
     @Override
     public short getShort() {
-        assert remaining()  >= Short.BYTES;
+        assert remaining() >= Short.BYTES;
 
         final ByteBuffer shortBuf = shortBufCache.get();
         try {

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
@@ -141,7 +141,7 @@ public final class FileChannelBuffer extends Buffer {
         final ByteBuffer byteBuf = byteBufCache.get();
         try {
             final int c = ch.read(byteBuf, this.offset + this.position);
-            assert c == 1;
+            assert c == Byte.BYTES;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -158,7 +158,7 @@ public final class FileChannelBuffer extends Buffer {
         final ByteBuffer byteBuf = byteBufCache.get();
         try {
             final int c = ch.read(byteBuf, this.offset + index);
-            assert c == 1;
+            assert c == Byte.BYTES;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -168,30 +168,30 @@ public final class FileChannelBuffer extends Buffer {
 
     @Override
     public int getInt() {
-        assert remaining() >= 4;
+        assert remaining() >= Integer.BYTES;;
 
         final ByteBuffer intBuf = intBufCache.get();
         intBuf.rewind();
         try {
             final int c = ch.read(intBuf, this.offset + this.position);
-            assert c == 4;
+            assert c == Integer.BYTES;;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
 
-        this.position += 4;
+        this.position += Integer.BYTES;
 
         return intBuf.getInt(0);
     }
 
     @Override
     public int getInt(final long index) {
-        assert index + 4 <= limit;
+        assert index + Integer.BYTES <= limit;
 
         final ByteBuffer intBuf = intBufCache.get();
         try {
             final int c = ch.read(intBuf, this.offset + index);
-            assert c == 4;
+            assert c == Integer.BYTES;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -201,17 +201,17 @@ public final class FileChannelBuffer extends Buffer {
 
     @Override
     public long getLong() {
-        assert remaining() >= 8;
+        assert remaining() >= Long.BYTES;
 
         final ByteBuffer longBuf = longBufCache.get();
         try {
             final int c = ch.read(longBuf, this.offset + this.position);
-            assert c == 8;
+            assert c == Long.BYTES;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
 
-        this.position += 8;
+        this.position += Long.BYTES;
 
         return longBuf.getLong(0);
     }
@@ -223,7 +223,7 @@ public final class FileChannelBuffer extends Buffer {
         final ByteBuffer longBuf = longBufCache.get();
         try {
             final int c = ch.read(longBuf, this.offset + index);
-            assert c == 8;
+            assert c == Long.BYTES;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
@@ -167,39 +167,6 @@ public final class FileChannelBuffer extends Buffer {
     }
 
     @Override
-    public short getShort() {
-        assert remaining() >= Short.BYTES;
-
-        final ByteBuffer shortBuf = shortBufCache.get();
-        shortBuf.rewind();
-        try {
-            final int c = ch.read(shortBuf, this.offset + this.position);
-            assert c == Short.BYTES;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        this.position += Short.BYTES;
-
-        return shortBuf.getShort(0);
-    }
-
-    @Override
-    public short getShort(long index) {
-        assert index + Short.BYTES <= limit;
-
-        final ByteBuffer shortBuf = shortBufCache.get();
-        try {
-            final int c = ch.read(shortBuf, this.offset + index);
-            assert c == Short.BYTES;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        return shortBuf.getShort(0);
-    }
-
-    @Override
     public int getInt() {
         assert remaining() >= Integer.BYTES;;
 
@@ -391,21 +358,6 @@ public final class FileChannelBuffer extends Buffer {
                 @Override
                 protected ByteBuffer initialValue() {
                     return ByteBuffer.allocate(8);
-                }
-
-                @Override
-                public ByteBuffer get() {
-                    final ByteBuffer result = super.get();
-                    result.rewind();
-                    return result;
-                }
-            };
-
-    private final ThreadLocal<ByteBuffer> shortBufCache =
-            new ThreadLocal<ByteBuffer>() {
-                @Override
-                protected ByteBuffer initialValue() {
-                    return ByteBuffer.allocate(Short.BYTES);
                 }
 
                 @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/buf/FileChannelBuffer.java
@@ -232,6 +232,70 @@ public final class FileChannelBuffer extends Buffer {
     }
 
     @Override
+    public char getChar() {
+        assert remaining()  >= Character.BYTES;
+
+        final ByteBuffer charBuf = charBufCache.get();
+        try {
+            final int c = ch.read(charBuf, this.offset + this.position);
+            assert c == Character.BYTES;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.position += Character.BYTES;
+
+        return charBuf.getChar(0);
+    }
+
+    @Override
+    public char getChar(final long index) {
+        assert index + Character.BYTES <= limit;
+
+        final ByteBuffer charBuf = charBufCache.get();
+        try {
+            final int c = ch.read(charBuf, this.offset + index);
+            assert c == Character.BYTES;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return charBuf.getChar(0);
+    }
+
+    @Override
+    public short getShort() {
+        assert remaining()  >= Short.BYTES;
+
+        final ByteBuffer shortBuf = shortBufCache.get();
+        try {
+            final int c = ch.read(shortBuf, this.offset + this.position);
+            assert c == Short.BYTES;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.position += Short.BYTES;
+
+        return shortBuf.getShort(0);
+    }
+
+    @Override
+    public short getShort(final long index) {
+        assert index + Short.BYTES <= limit;
+
+        final ByteBuffer shortBuf = shortBufCache.get();
+        try {
+            final int c = ch.read(shortBuf, this.offset + index);
+            assert c == Short.BYTES;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return shortBuf.getShort(0);
+    }
+
+    @Override
     public Buffer slice(final long from, final long size) {
         assert 0 <= from;
         assert 0 <= size;
@@ -277,6 +341,36 @@ public final class FileChannelBuffer extends Buffer {
                 @Override
                 protected ByteBuffer initialValue() {
                     return ByteBuffer.allocate(8);
+                }
+
+                @Override
+                public ByteBuffer get() {
+                    final ByteBuffer result = super.get();
+                    result.rewind();
+                    return result;
+                }
+            };
+
+    private final ThreadLocal<ByteBuffer> shortBufCache =
+            new ThreadLocal<ByteBuffer>() {
+                @Override
+                protected ByteBuffer initialValue() {
+                    return ByteBuffer.allocate(Short.BYTES);
+                }
+
+                @Override
+                public ByteBuffer get() {
+                    final ByteBuffer result = super.get();
+                    result.rewind();
+                    return result;
+                }
+            };
+
+    private final ThreadLocal<ByteBuffer> charBufCache =
+            new ThreadLocal<ByteBuffer>() {
+                @Override
+                protected ByteBuffer initialValue() {
+                    return ByteBuffer.allocate(Character.BYTES);
                 }
 
                 @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
@@ -22,17 +22,17 @@ import org.jetbrains.annotations.NotNull;
 @ThreadSafe
 public interface ByteArrayIndexedList {
     @NotNull
-    Buffer get(int i);
+    Buffer get(final int docId);
 
-    long getLongUnsafe(int i);
+    long getLongUnsafe(final int docId);
 
-    int getIntUnsafe(int i);
+    int getIntUnsafe(final int docId);
 
-    short getShortUnsafe(int i);
+    short getShortUnsafe(final int docId);
 
-    char getCharUnsafe(int i);
+    char getCharUnsafe(final int docId);
 
-    byte getByteUnsafe(int i);
+    byte getByteUnsafe(final int docId);
 
     int size();
 }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
@@ -32,5 +32,7 @@ public interface ByteArrayIndexedList {
 
     char getCharUnsafe(int i);
 
+    byte getByteUnsafe(int i);
+
     int size();
 }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
@@ -28,5 +28,9 @@ public interface ByteArrayIndexedList {
 
     int getIntUnsafe(int i);
 
+    short getShortUnsafe(int i);
+
+    char getCharUnsafe(int i);
+
     int size();
 }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedList.java
@@ -24,5 +24,9 @@ public interface ByteArrayIndexedList {
     @NotNull
     Buffer get(int i);
 
+    long getLongUnsafe(int i);
+
+    int getIntUnsafe(int i);
+
     int size();
 }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
@@ -26,6 +26,10 @@ public interface ByteArraySortedSet {
     @NotNull
     Buffer get(int i);
 
+    long getLongUnsafe(int i);
+
+    int getIntUnsafe(int i);
+
     /**
      * Get index of the element
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
@@ -34,6 +34,8 @@ public interface ByteArraySortedSet {
 
     char getCharUnsafe(int i);
 
+    byte getByteUnsafe(int i);
+
     /**
      * Get index of the element
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSet.java
@@ -30,6 +30,10 @@ public interface ByteArraySortedSet {
 
     int getIntUnsafe(int i);
 
+    short getShortUnsafe(int i);
+
+    char getCharUnsafe(int i);
+
     /**
      * Get index of the element
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -10,13 +10,11 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
-import com.google.common.primitives.Bytes;
-import com.google.common.primitives.Chars;
 import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
+import com.yandex.yoctodb.util.immutable.ByteArrayIndexedList;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
-import com.yandex.yoctodb.util.immutable.ByteArrayIndexedList;
 
 /**
  * Fixed length immutable implementation of {@link ByteArrayIndexedList}

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -10,6 +10,8 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
@@ -83,9 +85,7 @@ public class FixedLengthByteArrayIndexedList
 
         final int res = elements.getShort() ^ Short.MIN_VALUE;
 
-        assert res >= Short.MIN_VALUE && res <= Short.MAX_VALUE;
-
-        return (short) res;
+        return Shorts.checkedCast(res);
     }
 
     @Override
@@ -95,9 +95,7 @@ public class FixedLengthByteArrayIndexedList
 
         final int res = elements.getChar() ^ Character.MIN_VALUE;
 
-        assert res >= Character.MIN_VALUE && res <= Character.MAX_VALUE;
-
-        return (char) res;
+        return Chars.checkedCast(res);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -93,9 +93,7 @@ public class FixedLengthByteArrayIndexedList
         assert 0 <= i && i < elementCount;
         assert elementSize == Character.BYTES;
 
-        final int res = elements.getChar();
-
-        return (char) res;
+        return elements.getChar();
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -77,6 +77,30 @@ public class FixedLengthByteArrayIndexedList
     }
 
     @Override
+    public short getShortUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+        assert elementSize == Short.BYTES;
+
+        final int res = elements.getShort() ^ Short.MIN_VALUE;
+
+        assert res >= Short.MIN_VALUE && res <= Short.MAX_VALUE;
+
+        return (short) res;
+    }
+
+    @Override
+    public char getCharUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+        assert elementSize == Character.BYTES;
+
+        final int res = elements.getChar() ^ Character.MIN_VALUE;
+
+        assert res >= Character.MIN_VALUE && res <= Character.MAX_VALUE;
+
+        return (char) res;
+    }
+
+    @Override
     public int size() {
         return elementCount;
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -100,7 +100,11 @@ public class FixedLengthByteArrayIndexedList
         assert 0 <= i && i < elementCount;
         assert elementSize == Byte.BYTES;
 
-        return elements.get();
+        final int res = elements.get() ^ Byte.MIN_VALUE;
+
+        assert Byte.MIN_VALUE <= res && res <= Byte.MAX_VALUE;
+
+        return (byte) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -93,9 +93,9 @@ public class FixedLengthByteArrayIndexedList
         assert 0 <= i && i < elementCount;
         assert elementSize == Character.BYTES;
 
-        final int res = elements.getChar() ^ Character.MIN_VALUE;
+        final int res = elements.getChar();
 
-        return Chars.checkedCast(res);
+        return (char) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -10,6 +10,7 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
+import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Chars;
 import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
@@ -94,6 +95,14 @@ public class FixedLengthByteArrayIndexedList
         assert elementSize == Character.BYTES;
 
         return elements.getChar();
+    }
+
+    @Override
+    public byte getByteUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+        assert elementSize == Byte.BYTES;
+
+        return elements.get();
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArrayIndexedList.java
@@ -61,6 +61,22 @@ public class FixedLengthByteArrayIndexedList
     }
 
     @Override
+    public long getLongUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+        assert elementSize == Long.BYTES;
+
+        return elements.getLong() ^ Long.MIN_VALUE;
+    }
+
+    @Override
+    public int getIntUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+        assert elementSize == Integer.BYTES;
+
+        return elements.getInt() ^ Integer.MIN_VALUE;
+    }
+
+    @Override
     public int size() {
         return elementCount;
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -126,7 +126,11 @@ public final class FixedLengthByteArraySortedSet
 
         assert elementSize == Byte.BYTES;
 
-        return elements.get(((long) i) << 1);
+        final int res = elements.get(((long) i)) ^ Byte.MIN_VALUE;
+
+        assert Byte.MIN_VALUE <= res && res <= Byte.MAX_VALUE;
+
+        return (byte) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -11,13 +11,11 @@
 package com.yandex.yoctodb.util.immutable.impl;
 
 import com.google.common.primitives.Chars;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
+import com.yandex.yoctodb.util.UnsignedByteArrays;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
-import com.yandex.yoctodb.util.UnsignedByteArrays;
-import com.yandex.yoctodb.util.immutable.ByteArraySortedSet;
 
 /**
  * {@link com.yandex.yoctodb.util.immutable.ByteArraySortedSet} with fixed size
@@ -120,6 +118,15 @@ public final class FixedLengthByteArraySortedSet
         assert elementSize == Chars.BYTES;
 
         return elements.getChar(((long) i) << 1);
+    }
+
+    @Override
+    public byte getByteUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        assert elementSize == Byte.BYTES;
+
+        return elements.get(((long) i) << 1);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -82,6 +82,20 @@ public final class FixedLengthByteArraySortedSet
     }
 
     @Override
+    public long getLongUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        return elements.getLong(((long) i) * elementSize) ^ Long.MIN_VALUE;
+    }
+
+    @Override
+    public int getIntUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        return elements.getInt(((long) i) * elementSize) ^ Integer.MIN_VALUE;
+    }
+
+    @Override
     public String toString() {
         return "FixedLengthByteArraySortedSet{" +
                "elementSize=" + elementSize +

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -107,7 +107,7 @@ public final class FixedLengthByteArraySortedSet
     }
 
     @Override
-    public char getCharUnsafe(int i) {
+    public char getCharUnsafe(final int i) {
         assert 0 <= i && i < size;
 
         final int res = elements.getChar(((long) i) * elementSize) ^ Character.MIN_VALUE;

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -96,6 +96,28 @@ public final class FixedLengthByteArraySortedSet
     }
 
     @Override
+    public short getShortUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        final int res = elements.getShort(((long) i) * elementSize) ^ Short.MIN_VALUE;
+
+        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
+
+        return (short) res;
+    }
+
+    @Override
+    public char getCharUnsafe(int i) {
+        assert 0 <= i && i < size;
+
+        final int res = elements.getChar(((long) i) * elementSize) ^ Character.MIN_VALUE;
+
+        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
+
+        return (char) res;
+    }
+
+    @Override
     public String toString() {
         return "FixedLengthByteArraySortedSet{" +
                "elementSize=" + elementSize +

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -10,6 +10,9 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
@@ -85,36 +88,40 @@ public final class FixedLengthByteArraySortedSet
     public long getLongUnsafe(final int i) {
         assert 0 <= i && i < size;
 
-        return elements.getLong(((long) i) * elementSize) ^ Long.MIN_VALUE;
+        assert elementSize == Long.BYTES;
+
+        return elements.getLong(((long) i) << 3) ^ Long.MIN_VALUE;
     }
 
     @Override
     public int getIntUnsafe(final int i) {
         assert 0 <= i && i < size;
 
-        return elements.getInt(((long) i) * elementSize) ^ Integer.MIN_VALUE;
+        assert elementSize == Integer.BYTES;
+
+        return elements.getInt(((long) i) << 2) ^ Integer.MIN_VALUE;
     }
 
     @Override
     public short getShortUnsafe(final int i) {
         assert 0 <= i && i < size;
 
-        final int res = elements.getShort(((long) i) * elementSize) ^ Short.MIN_VALUE;
+        assert elementSize == Short.BYTES;
 
-        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
+        final int res = elements.getShort(((long) i) << 1) ^ Short.MIN_VALUE;
 
-        return (short) res;
+        return Shorts.checkedCast(res);
     }
 
     @Override
     public char getCharUnsafe(final int i) {
         assert 0 <= i && i < size;
 
-        final int res = elements.getChar(((long) i) * elementSize) ^ Character.MIN_VALUE;
+        assert elementSize == Chars.BYTES;
 
-        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
+        final int res = elements.getChar(((long) i) << 1) ^ Character.MIN_VALUE;
 
-        return (char) res;
+        return Chars.checkedCast(res);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -119,9 +119,7 @@ public final class FixedLengthByteArraySortedSet
 
         assert elementSize == Chars.BYTES;
 
-        final int res = elements.getChar(((long) i) << 1);
-
-        return (char) res;
+        return elements.getChar(((long) i) << 1);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -121,7 +121,7 @@ public final class FixedLengthByteArraySortedSet
 
         final int res = elements.getChar(((long) i) << 1);
 
-        return Chars.checkedCast(res);
+        return (char) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FixedLengthByteArraySortedSet.java
@@ -119,7 +119,7 @@ public final class FixedLengthByteArraySortedSet
 
         assert elementSize == Chars.BYTES;
 
-        final int res = elements.getChar(((long) i) << 1) ^ Character.MIN_VALUE;
+        final int res = elements.getChar(((long) i) << 1);
 
         return Chars.checkedCast(res);
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedList.java
@@ -1,3 +1,13 @@
+/*
+ * (C) YANDEX LLC, 2014-2019
+ *
+ * The Source Code called "YoctoDB" available at
+ * https://github.com/yandex/yoctodb is subject to the terms of the
+ * Mozilla Public License, v. 2.0 (hereinafter referred to as the "License").
+ *
+ * A copy of the License is also available at http://mozilla.org/MPL/2.0/.
+ */
+
 package com.yandex.yoctodb.util.immutable.impl;
 
 import com.yandex.yoctodb.util.buf.Buffer;
@@ -90,6 +100,56 @@ public final class FoldedByteArrayIndexedList implements ByteArrayIndexedList {
         final long start = offsets.getLong(offsetIndex);
         final long end = offsets.getLong(offsetIndex + Long.BYTES);
         return elements.slice(start, end - start);
+    }
+
+    @Override
+    public long getLongUnsafe(final int docId) {
+        assert 0 <= docId && docId < elementCount;
+
+        final long offsetIndex = getOffsetIndex.apply(docId) * Long.BYTES;
+        final long start = offsets.getLong(offsetIndex);
+
+        return elements.getLong(start) ^ Long.MIN_VALUE;
+    }
+
+    @Override
+    public int getIntUnsafe(final int docId) {
+        assert 0 <= docId && docId < elementCount;
+
+        final long offsetIndex = getOffsetIndex.apply(docId) * Long.BYTES;
+        final long start = offsets.getLong(offsetIndex);
+
+        return elements.getInt(start) ^ Integer.MIN_VALUE;
+    }
+
+    @Override
+    public short getShortUnsafe(final int docId) {
+        assert 0 <= docId && docId < elementCount;
+
+        final long offsetIndex = getOffsetIndex.apply(docId) * Long.BYTES;
+        final long start = offsets.getLong(offsetIndex);
+
+        return (short) (elements.getShort(start) ^ Short.MIN_VALUE);
+    }
+
+    @Override
+    public char getCharUnsafe(final int docId) {
+        assert 0 <= docId && docId < elementCount;
+
+        final long offsetIndex = getOffsetIndex.apply(docId) * Long.BYTES;
+        final long start = offsets.getLong(offsetIndex);
+
+        return elements.getChar(start);
+    }
+
+    @Override
+    public byte getByteUnsafe(final int docId) {
+        assert 0 <= docId && docId < elementCount;
+
+        final long offsetIndex = getOffsetIndex.apply(docId) * Long.BYTES;
+        final long start = offsets.getLong(offsetIndex);
+
+        return (byte) (elements.get(start) ^ Byte.MIN_VALUE);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
@@ -117,7 +117,19 @@ public class TrieByteArraySortedSet implements ByteArraySortedSet {
         throw new UnsupportedOperationException();
     }
 
-    /**
+	/**
+	 * We unable to provide getByteUnsafe() implementation since
+	 * there is no continuous buffer with key value.
+	 *
+	 * @param i index of key
+	 * @throws UnsupportedOperationException
+	 */
+	@Override
+	public byte getByteUnsafe(int i) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
      * Look up for key in trie.
      * Complexity: O(|key|)
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
@@ -117,19 +117,19 @@ public class TrieByteArraySortedSet implements ByteArraySortedSet {
         throw new UnsupportedOperationException();
     }
 
-	/**
-	 * We unable to provide getByteUnsafe() implementation since
-	 * there is no continuous buffer with key value.
-	 *
-	 * @param i index of key
-	 * @throws UnsupportedOperationException
-	 */
-	@Override
-	public byte getByteUnsafe(int i) {
-		throw new UnsupportedOperationException();
-	}
+    /**
+     * We unable to provide getByteUnsafe() implementation since
+     * there is no continuous buffer with key value.
+     *
+     * @param i index of key
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public byte getByteUnsafe(int i) {
+        throw new UnsupportedOperationException();
+    }
 
-	/**
+    /**
      * Look up for key in trie.
      * Complexity: O(|key|)
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSet.java
@@ -70,6 +70,54 @@ public class TrieByteArraySortedSet implements ByteArraySortedSet {
     }
 
     /**
+     * We unable to provide getLongUnsafe() implementation since
+     * there is no continuous buffer with key value.
+     *
+     * @param i index of key
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public long getLongUnsafe(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * We unable to provide getIntUnsafe() implementation since
+     * there is no continuous buffer with key value.
+     *
+     * @param i index of key
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public int getIntUnsafe(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * We unable to provide getShortUnsafe() implementation since
+     * there is no continuous buffer with key value.
+     *
+     * @param i index of key
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public short getShortUnsafe(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * We unable to provide getCharUnsafe() implementation since
+     * there is no continuous buffer with key value.
+     *
+     * @param i index of key
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public char getCharUnsafe(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Look up for key in trie.
      * Complexity: O(|key|)
      *

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -71,6 +71,26 @@ public class VariableLengthByteArrayIndexedList
     }
 
     @Override
+    public long getLongUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+
+        return elements.getLong(start) ^ Long.MIN_VALUE;
+    }
+
+    @Override
+    public int getIntUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+
+        return elements.getInt(start) ^ Integer.MIN_VALUE;
+    }
+
+    @Override
     public int size() {
         return elementCount;
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -115,9 +115,9 @@ public class VariableLengthByteArrayIndexedList
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Character.BYTES;
-        final int res = elements.getShort(start) ^ Character.MIN_VALUE;
+        final int res = elements.getChar(start);
 
-        return Chars.checkedCast(res);
+        return (char) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -10,6 +10,8 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
@@ -100,9 +102,8 @@ public class VariableLengthByteArrayIndexedList
 
         assert end - start == Short.BYTES;
         final int res = elements.getShort(start) ^ Short.MIN_VALUE;
-        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
 
-        return (short) res;
+        return Shorts.checkedCast(res);
     }
 
     @Override
@@ -115,9 +116,8 @@ public class VariableLengthByteArrayIndexedList
 
         assert end - start == Character.BYTES;
         final int res = elements.getShort(start) ^ Character.MIN_VALUE;
-        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
 
-        return (char) res;
+        return Chars.checkedCast(res);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -91,6 +91,36 @@ public class VariableLengthByteArrayIndexedList
     }
 
     @Override
+    public short getShortUnsafe(int i) {
+        assert 0 <= i && i < elementCount;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Short.BYTES;
+        final int res = elements.getShort(start) ^ Short.MIN_VALUE;
+        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
+
+        return (short) res;
+    }
+
+    @Override
+    public char getCharUnsafe(int i) {
+        assert 0 <= i && i < elementCount;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Character.BYTES;
+        final int res = elements.getShort(start) ^ Character.MIN_VALUE;
+        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
+
+        return (char) res;
+    }
+
+    @Override
     public int size() {
         return elementCount;
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -115,9 +115,8 @@ public class VariableLengthByteArrayIndexedList
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Character.BYTES;
-        final int res = elements.getChar(start);
 
-        return (char) res;
+        return elements.getChar(start);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -120,6 +120,19 @@ public class VariableLengthByteArrayIndexedList
     }
 
     @Override
+    public byte getByteUnsafe(final int i) {
+        assert 0 <= i && i < elementCount;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Byte.BYTES;
+
+        return elements.get(start);
+    }
+
+    @Override
     public int size() {
         return elementCount;
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -91,7 +91,7 @@ public class VariableLengthByteArrayIndexedList
     }
 
     @Override
-    public short getShortUnsafe(int i) {
+    public short getShortUnsafe(final int i) {
         assert 0 <= i && i < elementCount;
 
         final long base = ((long) i) << 3;
@@ -106,7 +106,7 @@ public class VariableLengthByteArrayIndexedList
     }
 
     @Override
-    public char getCharUnsafe(int i) {
+    public char getCharUnsafe(final int i) {
         assert 0 <= i && i < elementCount;
 
         final long base = ((long) i) << 3;

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArrayIndexedList.java
@@ -10,12 +10,11 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
-import com.google.common.primitives.Chars;
 import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
+import com.yandex.yoctodb.util.immutable.ByteArrayIndexedList;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
-import com.yandex.yoctodb.util.immutable.ByteArrayIndexedList;
 
 /**
  * Variable length immutable implementation of
@@ -128,8 +127,11 @@ public class VariableLengthByteArrayIndexedList
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Byte.BYTES;
+        final int res = elements.get(start) ^ Byte.MIN_VALUE;
 
-        return elements.get(start);
+        assert Byte.MIN_VALUE <= res && res <= Byte.MAX_VALUE;
+
+        return (byte) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -10,6 +10,8 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
@@ -135,7 +137,7 @@ public final class VariableLengthByteArraySortedSet
         final int res = elements.getShort(start) ^ Short.MIN_VALUE;
         assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
 
-        return (short) res;
+        return Shorts.checkedCast(res);
     }
 
     @Override
@@ -148,9 +150,8 @@ public final class VariableLengthByteArraySortedSet
 
         assert end - start == Character.BYTES;
         final int res = elements.getChar(start) ^ Character.MIN_VALUE;
-        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
 
-        return (char) res;
+        return Chars.checkedCast(res);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -11,6 +11,7 @@
 package com.yandex.yoctodb.util.immutable.impl;
 
 import com.google.common.primitives.Chars;
+import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
@@ -135,7 +136,6 @@ public final class VariableLengthByteArraySortedSet
 
         assert end - start == Short.BYTES;
         final int res = elements.getShort(start) ^ Short.MIN_VALUE;
-        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
 
         return Shorts.checkedCast(res);
     }
@@ -149,7 +149,7 @@ public final class VariableLengthByteArraySortedSet
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Character.BYTES;
-        final int res = elements.getChar(start) ^ Character.MIN_VALUE;
+        final int res = elements.getChar(start);
 
         return Chars.checkedCast(res);
     }

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -154,6 +154,19 @@ public final class VariableLengthByteArraySortedSet
     }
 
     @Override
+    public byte getByteUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Character.BYTES;
+
+        return elements.get(start);
+    }
+
+    @Override
     public String toString() {
         return "VariableLengthByteArraySortedSet{" +
                "size=" + size +

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -149,9 +149,8 @@ public final class VariableLengthByteArraySortedSet
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Character.BYTES;
-        final int res = elements.getChar(start);
 
-        return (char) res;
+        return elements.getChar(start);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -124,6 +124,36 @@ public final class VariableLengthByteArraySortedSet
     }
 
     @Override
+    public short getShortUnsafe(int i) {
+        assert 0 <= i && i < size;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Short.BYTES;
+        final int res = elements.getShort(start) ^ Short.MIN_VALUE;
+        assert Short.MIN_VALUE <= res && res <= Short.MAX_VALUE;
+
+        return (short) res;
+    }
+
+    @Override
+    public char getCharUnsafe(int i) {
+        assert 0 <= i && i < size;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Character.BYTES;
+        final int res = elements.getShort(start) ^ Character.MIN_VALUE;
+        assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
+
+        return (char) res;
+    }
+
+    @Override
     public String toString() {
         return "VariableLengthByteArraySortedSet{" +
                "size=" + size +

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -10,14 +10,11 @@
 
 package com.yandex.yoctodb.util.immutable.impl;
 
-import com.google.common.primitives.Chars;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
+import com.yandex.yoctodb.util.UnsignedByteArrays;
 import com.yandex.yoctodb.util.buf.Buffer;
 import net.jcip.annotations.Immutable;
 import org.jetbrains.annotations.NotNull;
-import com.yandex.yoctodb.util.UnsignedByteArrays;
-import com.yandex.yoctodb.util.immutable.ByteArraySortedSet;
 
 /**
  * {@link com.yandex.yoctodb.util.immutable.ByteArraySortedSet} with variable
@@ -161,9 +158,10 @@ public final class VariableLengthByteArraySortedSet
         final long start = offsets.getLong(base);
         final long end = offsets.getLong(base + 8L);
 
-        assert end - start == Character.BYTES;
+        assert end - start == Byte.BYTES;
 
-        return elements.get(start);
+        final int res = elements.get(start) ^ Byte.MIN_VALUE;
+        return (byte) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -98,6 +98,32 @@ public final class VariableLengthByteArraySortedSet
     }
 
     @Override
+    public long getLongUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Long.BYTES;
+
+        return elements.getLong(start) ^ Long.MIN_VALUE;
+    }
+
+    @Override
+    public int getIntUnsafe(final int i) {
+        assert 0 <= i && i < size;
+
+        final long base = ((long) i) << 3;
+        final long start = offsets.getLong(base);
+        final long end = offsets.getLong(base + 8L);
+
+        assert end - start == Integer.BYTES;
+
+        return elements.getInt(start) ^ Integer.MIN_VALUE;
+    }
+
+    @Override
     public String toString() {
         return "VariableLengthByteArraySortedSet{" +
                "size=" + size +

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -124,7 +124,7 @@ public final class VariableLengthByteArraySortedSet
     }
 
     @Override
-    public short getShortUnsafe(int i) {
+    public short getShortUnsafe(final int i) {
         assert 0 <= i && i < size;
 
         final long base = ((long) i) << 3;
@@ -139,7 +139,7 @@ public final class VariableLengthByteArraySortedSet
     }
 
     @Override
-    public char getCharUnsafe(int i) {
+    public char getCharUnsafe(final int i) {
         assert 0 <= i && i < size;
 
         final long base = ((long) i) << 3;

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -151,7 +151,7 @@ public final class VariableLengthByteArraySortedSet
         assert end - start == Character.BYTES;
         final int res = elements.getChar(start);
 
-        return Chars.checkedCast(res);
+        return (char) res;
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/immutable/impl/VariableLengthByteArraySortedSet.java
@@ -147,7 +147,7 @@ public final class VariableLengthByteArraySortedSet
         final long end = offsets.getLong(base + 8L);
 
         assert end - start == Character.BYTES;
-        final int res = elements.getShort(start) ^ Character.MIN_VALUE;
+        final int res = elements.getChar(start) ^ Character.MIN_VALUE;
         assert Character.MIN_VALUE <= res && res <= Character.MAX_VALUE;
 
         return (char) res;

--- a/core/src/main/java/com/yandex/yoctodb/util/mutable/impl/FoldedByteArrayIndexedList.java
+++ b/core/src/main/java/com/yandex/yoctodb/util/mutable/impl/FoldedByteArrayIndexedList.java
@@ -1,3 +1,13 @@
+/*
+ * (C) YANDEX LLC, 2014-2019
+ *
+ * The Source Code called "YoctoDB" available at
+ * https://github.com/yandex/yoctodb is subject to the terms of the
+ * Mozilla Public License, v. 2.0 (hereinafter referred to as the "License").
+ *
+ * A copy of the License is also available at http://mozilla.org/MPL/2.0/.
+ */
+
 package com.yandex.yoctodb.util.mutable.impl;
 
 import com.google.common.primitives.Ints;

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
@@ -127,6 +127,32 @@ public final class V1CompositeDatabase implements Database {
     }
 
     @Override
+    public short getShortValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        final int dbIndex = databaseByDocIndex(document);
+        return databases.get(dbIndex)
+                .getShortValue(
+                        document - documentOffsets[dbIndex],
+                        fieldName
+                );
+    }
+
+    @Override
+    public char getCharValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        final int dbIndex = databaseByDocIndex(document);
+        return databases.get(dbIndex)
+                .getCharValue(
+                        document - documentOffsets[dbIndex],
+                        fieldName
+                );
+    }
+
+    @Override
     public void execute(
             @NotNull
             final Query query,

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
@@ -153,6 +153,19 @@ public final class V1CompositeDatabase implements Database {
     }
 
     @Override
+    public byte getByteValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        final int dbIndex = databaseByDocIndex(document);
+        return databases.get(dbIndex)
+                .getByteValue(
+                        document - documentOffsets[dbIndex],
+                        fieldName
+                );
+    }
+
+    @Override
     public void execute(
             @NotNull
             final Query query,

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1CompositeDatabase.java
@@ -102,6 +102,31 @@ public final class V1CompositeDatabase implements Database {
     }
 
     @Override
+    public long getLongValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        final int dbIndex = databaseByDocIndex(document);
+        return databases.get(dbIndex)
+                .getLongValue(
+                        document - documentOffsets[dbIndex],
+                        fieldName);
+    }
+
+    @Override
+    public int getIntValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        final int dbIndex = databaseByDocIndex(document);
+        return databases.get(dbIndex)
+                .getIntValue(
+                        document - documentOffsets[dbIndex],
+                        fieldName
+                );
+    }
+
+    @Override
     public void execute(
             @NotNull
             final Query query,

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
@@ -145,12 +145,22 @@ public final class V1Database implements IndexedDatabase {
 
     @Override
     public char getCharValue(
-            int document,
+            final int document,
             @NotNull
             final String fieldName) {
         assert storers.containsKey(fieldName);
 
         return storers.get(fieldName).getCharValue(document);
+    }
+
+    @Override
+    public byte getByteValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        assert storers.containsKey(fieldName);
+
+        return storers.get(fieldName).getByteValue(document);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
@@ -114,6 +114,26 @@ public final class V1Database implements IndexedDatabase {
     }
 
     @Override
+    public long getLongValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        assert storers.containsKey(fieldName);
+
+        return storers.get(fieldName).getLongValue(document);
+    }
+
+    @Override
+    public int getIntValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        assert  storers.containsKey(fieldName);
+
+        return storers.get(fieldName).getIntValue(document);
+    }
+
+    @Override
     public void execute(
             @NotNull
             final Query query,

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/V1Database.java
@@ -128,9 +128,29 @@ public final class V1Database implements IndexedDatabase {
             final int document,
             @NotNull
             final String fieldName) {
-        assert  storers.containsKey(fieldName);
+        assert storers.containsKey(fieldName);
 
         return storers.get(fieldName).getIntValue(document);
+    }
+
+    @Override
+    public short getShortValue(
+            final int document,
+            @NotNull
+            final String fieldName) {
+        assert storers.containsKey(fieldName);
+
+        return storers.get(fieldName).getShortValue(document);
+    }
+
+    @Override
+    public char getCharValue(
+            int document,
+            @NotNull
+            final String fieldName) {
+        assert storers.containsKey(fieldName);
+
+        return storers.get(fieldName).getCharValue(document);
     }
 
     @Override

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
@@ -157,6 +157,16 @@ public final class V1FullIndex
         return sortableDelegate.getIntValue(document);
     }
 
+    @Override
+    public short getShortValue(int document) {
+        return sortableDelegate.getShortValue(document);
+    }
+
+    @Override
+    public char getCharValue(int document) {
+        return sortableDelegate.getCharValue(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
@@ -158,12 +158,12 @@ public final class V1FullIndex
     }
 
     @Override
-    public short getShortValue(int document) {
+    public short getShortValue(final int document) {
         return sortableDelegate.getShortValue(document);
     }
 
     @Override
-    public char getCharValue(int document) {
+    public char getCharValue(final int document) {
         return sortableDelegate.getCharValue(document);
     }
 

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
@@ -147,6 +147,16 @@ public final class V1FullIndex
         return sortableDelegate.getStoredValue(document);
     }
 
+    @Override
+    public long getLongValue(final int document) {
+        return sortableDelegate.getLongValue(document);
+    }
+
+    @Override
+    public int getIntValue(final int document) {
+        return sortableDelegate.getIntValue(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1FullIndex.java
@@ -167,6 +167,11 @@ public final class V1FullIndex
         return sortableDelegate.getCharValue(document);
     }
 
+    @Override
+    public byte getByteValue(final int document) {
+        return sortableDelegate.getByteValue(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
@@ -93,6 +93,16 @@ public final class V1SortableIndex
         return values.getIntUnsafe(document);
     }
 
+    @Override
+    public short getShortValue(int document) {
+        return values.getShortUnsafe(document);
+    }
+
+    @Override
+    public char getCharValue(int document) {
+        return values.getCharUnsafe(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
@@ -83,6 +83,16 @@ public final class V1SortableIndex
         return values.get(documentToValue.get(document));
     }
 
+    @Override
+    public long getLongValue(int document) {
+        return values.getLongUnsafe(document);
+    }
+
+    @Override
+    public int getIntValue(int document) {
+        return values.getIntUnsafe(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
@@ -103,6 +103,11 @@ public final class V1SortableIndex
         return values.getCharUnsafe(document);
     }
 
+    @Override
+    public byte getByteValue(final int document) {
+        return values.getByteUnsafe(document);
+    }
+
     @NotNull
     @Override
     public Iterator<IntToIntArray> ascending(

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1SortableIndex.java
@@ -84,22 +84,22 @@ public final class V1SortableIndex
     }
 
     @Override
-    public long getLongValue(int document) {
+    public long getLongValue(final int document) {
         return values.getLongUnsafe(document);
     }
 
     @Override
-    public int getIntValue(int document) {
+    public int getIntValue(final int document) {
         return values.getIntUnsafe(document);
     }
 
     @Override
-    public short getShortValue(int document) {
+    public short getShortValue(final int document) {
         return values.getShortUnsafe(document);
     }
 
     @Override
-    public char getCharValue(int document) {
+    public char getCharValue(final int document) {
         return values.getCharUnsafe(document);
     }
 

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
@@ -61,7 +61,7 @@ public class V1StoredIndex implements StoredIndex, Segment {
     }
 
     @Override
-    public byte getByteValue(int document) {
+    public byte getByteValue(final int document) {
         return values.getByteUnsafe(document);
     }
 

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
@@ -60,6 +60,11 @@ public class V1StoredIndex implements StoredIndex, Segment {
         return values.getCharUnsafe(document);
     }
 
+    @Override
+    public byte getByteValue(int document) {
+        return values.getByteUnsafe(document);
+    }
+
     static void registerReader() {
         SegmentRegistry.register(
                 V1DatabaseFormat.SegmentType

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
@@ -51,12 +51,12 @@ public class V1StoredIndex implements StoredIndex, Segment {
     }
 
     @Override
-    public short getShortValue(int document) {
+    public short getShortValue(final int document) {
         return values.getShortUnsafe(document);
     }
 
     @Override
-    public char getCharValue(int document) {
+    public char getCharValue(final int document) {
         return values.getCharUnsafe(document);
     }
 

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
@@ -40,6 +40,16 @@ public class V1StoredIndex implements StoredIndex, Segment {
         return values.get(document);
     }
 
+    @Override
+    public long getLongValue(final int document) {
+        return values.getLongUnsafe(document);
+    }
+
+    @Override
+    public int getIntValue(final int document) {
+        return values.getIntUnsafe(document);
+    }
+
     static void registerReader() {
         SegmentRegistry.register(
                 V1DatabaseFormat.SegmentType

--- a/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
+++ b/core/src/main/java/com/yandex/yoctodb/v1/immutable/segment/V1StoredIndex.java
@@ -50,6 +50,16 @@ public class V1StoredIndex implements StoredIndex, Segment {
         return values.getIntUnsafe(document);
     }
 
+    @Override
+    public short getShortValue(int document) {
+        return values.getShortUnsafe(document);
+    }
+
+    @Override
+    public char getCharValue(int document) {
+        return values.getCharUnsafe(document);
+    }
+
     static void registerReader() {
         SegmentRegistry.register(
                 V1DatabaseFormat.SegmentType

--- a/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
@@ -101,6 +101,8 @@ public class CompositeFileDatabaseTest {
                             .withField("relevance", i, SORTABLE)
                             .withField("stored_long_value", Long.valueOf(i), STORED)
                             .withField("stored_int_value", i, STORED)
+                            .withField("stored_short_value", (short) i, STORED)
+                            .withField("stored_char_value", (char) i, STORED)
                             .withPayload(("payload2=" + i).getBytes())
             );
         }

--- a/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
@@ -49,6 +49,7 @@ public class CompositeFileDatabaseTest {
     private static final String INT_STORED_FILED_NAME = "stored_int_value";
     private static final String SHORT_STORED_FILED_NAME = "stored_short_value";
     private static final String CHAR_STORED_FILED_NAME = "stored_char_value";
+    private static final String BYTE_STORED_FIELD_NAME = "stored_byte_value";
 
     static {
         try {
@@ -82,6 +83,7 @@ public class CompositeFileDatabaseTest {
                             .withField(INT_STORED_FILED_NAME, i, STORED)
                             .withField(SHORT_STORED_FILED_NAME, (short) i, STORED)
                             .withField(CHAR_STORED_FILED_NAME, (char) i, STORED)
+                            .withField(BYTE_STORED_FIELD_NAME, (byte) i, STORED)
                             .withPayload(("payload1=" + i).getBytes())
             );
         }
@@ -109,6 +111,7 @@ public class CompositeFileDatabaseTest {
                             .withField(INT_STORED_FILED_NAME, i, STORED)
                             .withField(SHORT_STORED_FILED_NAME, (short) i, STORED)
                             .withField(CHAR_STORED_FILED_NAME, (char) i, STORED)
+                            .withField(BYTE_STORED_FIELD_NAME, (byte) i, STORED)
                             .withPayload(("payload2=" + i).getBytes())
             );
         }
@@ -645,6 +648,16 @@ public class CompositeFileDatabaseTest {
             assertEquals(
                     id,
                     db.getCharValue(id, CHAR_STORED_FILED_NAME));
+        }
+    }
+
+    @Test
+    public void extractFieldValueAsByte() {
+        for (int i = 0; i < 2 * DOCS; i++) {
+            final int id = i % DOCS;
+            assertEquals(
+                    id,
+                    db.getByteValue((byte) id, BYTE_STORED_FIELD_NAME));
         }
     }
 }

--- a/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
@@ -72,6 +72,8 @@ public class CompositeFileDatabaseTest {
                             .withField("field2", "2", FILTERABLE)
                             .withField("index", i, FULL)
                             .withField("relevance", -i, SORTABLE)
+                            .withField("stored_long_value", Long.valueOf(i), STORED)
+                            .withField("stored_int_value", i, STORED)
                             .withPayload(("payload1=" + i).getBytes())
             );
         }
@@ -95,6 +97,8 @@ public class CompositeFileDatabaseTest {
                             .withField("field2", "1", FILTERABLE)
                             .withField("index", i, FULL)
                             .withField("relevance", i, SORTABLE)
+                            .withField("stored_long_value", Long.valueOf(i), STORED)
+                            .withField("stored_int_value", i, STORED)
                             .withPayload(("payload2=" + i).getBytes())
             );
         }
@@ -529,7 +533,7 @@ public class CompositeFileDatabaseTest {
 
     @Test
     public void emptyCompositeDatabaseFieldSearch() {
-        final Database db = READER.composite(new ArrayList<IndexedDatabase>());
+        final Database db = READER.composite(new ArrayList<>());
 
         final Query query =
                 select().where(
@@ -591,6 +595,28 @@ public class CompositeFileDatabaseTest {
             assertEquals(
                     from(-id).toByteBuffer(),
                     db.getFieldValue(id, "relevance"));
+        }
+    }
+
+    @Test
+    public void extractFieldValuesAsLong() {
+        for (int i = 0; i < 2 * DOCS; i++) {
+            final int id = i % DOCS;
+            final long puttedValue = from(Long.valueOf(id)).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+            assertEquals(
+                    puttedValue,
+                    db.getLongValue(id, "stored_long_value"));
+        }
+    }
+
+    @Test
+    public void extractFieldValueAsInt() {
+        for (int i = 0; i < 2 * DOCS; i++) {
+            final int id = i % DOCS;
+            final long puttedValue = from(id).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+            assertEquals(
+                    puttedValue,
+                    db.getIntValue(id, "stored_int_value"));
         }
     }
 }

--- a/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
@@ -44,6 +44,11 @@ import static org.junit.Assert.assertEquals;
 public class CompositeFileDatabaseTest {
     private static final String BASE;
 
+    private static final String LONG_STORED_FILED_NAME = "stored_long_value";
+    private static final String INT_STORED_FILED_NAME = "stored_int_value";
+    private static final String SHORT_STORED_FILED_NAME = "stored_short_value";
+    private static final String CHAR_STORED_FILED_NAME = "stored_char_value";
+
     static {
         try {
             BASE = Files.createTempDirectory("indices").toString();
@@ -72,10 +77,10 @@ public class CompositeFileDatabaseTest {
                             .withField("field2", "2", FILTERABLE)
                             .withField("index", i, FULL)
                             .withField("relevance", -i, SORTABLE)
-                            .withField("stored_long_value", Long.valueOf(i), STORED)
-                            .withField("stored_int_value", i, STORED)
-                            .withField("stored_short_value", (short) i, STORED)
-                            .withField("stored_char_value", (char) i, STORED)
+                            .withField(LONG_STORED_FILED_NAME, Long.valueOf(i), STORED)
+                            .withField(INT_STORED_FILED_NAME, i, STORED)
+                            .withField(SHORT_STORED_FILED_NAME, (short) i, STORED)
+                            .withField(CHAR_STORED_FILED_NAME, (char) i, STORED)
                             .withPayload(("payload1=" + i).getBytes())
             );
         }
@@ -99,10 +104,10 @@ public class CompositeFileDatabaseTest {
                             .withField("field2", "1", FILTERABLE)
                             .withField("index", i, FULL)
                             .withField("relevance", i, SORTABLE)
-                            .withField("stored_long_value", Long.valueOf(i), STORED)
-                            .withField("stored_int_value", i, STORED)
-                            .withField("stored_short_value", (short) i, STORED)
-                            .withField("stored_char_value", (char) i, STORED)
+                            .withField(LONG_STORED_FILED_NAME, Long.valueOf(i), STORED)
+                            .withField(INT_STORED_FILED_NAME, i, STORED)
+                            .withField(SHORT_STORED_FILED_NAME, (short) i, STORED)
+                            .withField(CHAR_STORED_FILED_NAME, (char) i, STORED)
                             .withPayload(("payload2=" + i).getBytes())
             );
         }
@@ -606,10 +611,9 @@ public class CompositeFileDatabaseTest {
     public void extractFieldValuesAsLong() {
         for (int i = 0; i < 2 * DOCS; i++) {
             final int id = i % DOCS;
-            final long puttedValue = from(Long.valueOf(id)).toByteBuffer().getLong() ^ Long.MIN_VALUE;
             assertEquals(
-                    puttedValue,
-                    db.getLongValue(id, "stored_long_value"));
+                    id,
+                    db.getLongValue(id, LONG_STORED_FILED_NAME));
         }
     }
 
@@ -617,10 +621,9 @@ public class CompositeFileDatabaseTest {
     public void extractFieldValueAsInt() {
         for (int i = 0; i < 2 * DOCS; i++) {
             final int id = i % DOCS;
-            final long puttedValue = from(id).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
             assertEquals(
-                    puttedValue,
-                    db.getIntValue(id, "stored_int_value"));
+                    id,
+                    db.getIntValue(id, INT_STORED_FILED_NAME));
         }
     }
 
@@ -628,10 +631,9 @@ public class CompositeFileDatabaseTest {
     public void extractFieldValuesAsShort() {
         for (int i = 0; i < 2 * DOCS; i++) {
             final int id = i % DOCS;
-            final long puttedValue = from((short) id).toByteBuffer().getShort() ^ Short.MIN_VALUE;
             assertEquals(
-                    puttedValue,
-                    db.getShortValue(id, "stored_short_value"));
+                    id,
+                    db.getShortValue(id, SHORT_STORED_FILED_NAME));
         }
     }
 
@@ -639,10 +641,9 @@ public class CompositeFileDatabaseTest {
     public void extractFieldValueAsChar() {
         for (int i = 0; i < 2 * DOCS; i++) {
             final int id = i % DOCS;
-            final long puttedValue = from((char) id).toByteBuffer().getChar() ^ Character.MIN_VALUE;
             assertEquals(
-                    puttedValue,
-                    db.getCharValue(id, "stored_char_value"));
+                    id,
+                    db.getCharValue(id, CHAR_STORED_FILED_NAME));
         }
     }
 }

--- a/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/CompositeFileDatabaseTest.java
@@ -74,6 +74,8 @@ public class CompositeFileDatabaseTest {
                             .withField("relevance", -i, SORTABLE)
                             .withField("stored_long_value", Long.valueOf(i), STORED)
                             .withField("stored_int_value", i, STORED)
+                            .withField("stored_short_value", (short) i, STORED)
+                            .withField("stored_char_value", (char) i, STORED)
                             .withPayload(("payload1=" + i).getBytes())
             );
         }
@@ -617,6 +619,28 @@ public class CompositeFileDatabaseTest {
             assertEquals(
                     puttedValue,
                     db.getIntValue(id, "stored_int_value"));
+        }
+    }
+
+    @Test
+    public void extractFieldValuesAsShort() {
+        for (int i = 0; i < 2 * DOCS; i++) {
+            final int id = i % DOCS;
+            final long puttedValue = from((short) id).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+            assertEquals(
+                    puttedValue,
+                    db.getShortValue(id, "stored_short_value"));
+        }
+    }
+
+    @Test
+    public void extractFieldValueAsChar() {
+        for (int i = 0; i < 2 * DOCS; i++) {
+            final int id = i % DOCS;
+            final long puttedValue = from((char) id).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            assertEquals(
+                    puttedValue,
+                    db.getCharValue(id, "stored_char_value"));
         }
     }
 }

--- a/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
@@ -33,11 +33,13 @@ public class FieldValueExtractionTest {
     private static final String LONG_FIELD_NAME = "long_id";
     private static final String SHORT_FIELD_NAME = "short_id";
     private static final String CHAR_FIELD_NAME = "char_id";
+    private static final String BYTE_FIELD_NAME = "byte_is";
 
     private static final int INT_FIELD_VALUE = 25;
     private static final long LONG_FIELD_VALUE = 25L;
     private static final short SHORT_FIELD_VALUE = 25;
     private static final char CHAR_FIELD_VALUE = 'a';
+    private static final byte BYTE_FIELD_VALUE = 23;
 
 
     private DocumentProvider build(
@@ -57,6 +59,7 @@ public class FieldValueExtractionTest {
                         .withField(LONG_FIELD_NAME, LONG_FIELD_VALUE, indexOption)
                         .withField(SHORT_FIELD_NAME, SHORT_FIELD_VALUE, indexOption)
                         .withField(CHAR_FIELD_NAME, CHAR_FIELD_VALUE, indexOption)
+                        .withField(BYTE_FIELD_NAME, BYTE_FIELD_VALUE, indexOption)
                         .withPayload("payload".getBytes())
         );
 
@@ -114,6 +117,13 @@ public class FieldValueExtractionTest {
         final DocumentProvider db = build(IndexOption.STORED);
         final char storedValue = db.getCharValue(0, CHAR_FIELD_NAME);
         assertEquals(CHAR_FIELD_VALUE, storedValue);
+    }
+
+    @Test
+    public void extractStoredByte() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        final byte storedValue = db.getByteValue(0, BYTE_FIELD_NAME);
+        assertEquals(BYTE_FIELD_VALUE, storedValue);
     }
 
     @Test(expected = AssertionError.class)

--- a/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
@@ -31,6 +31,8 @@ public class FieldValueExtractionTest {
     private static final String FIELD_NAME = "id";
     private static final String INT_FIELD_NAME = "int_id";
     private static final String LONG_FIELD_NAME = "long_id";
+    private static final String SHORT_FIELD_NAME = "short_id";
+    private static final String CHAR_FIELD_NAME = "char_id";
 
     private DocumentProvider build(
             final IndexOption indexOption) throws IOException {
@@ -47,6 +49,8 @@ public class FieldValueExtractionTest {
                                 indexOption)
                         .withField(INT_FIELD_NAME, 25, indexOption)
                         .withField(LONG_FIELD_NAME, 25L, indexOption)
+                        .withField(SHORT_FIELD_NAME, (short) 25, indexOption)
+                        .withField(CHAR_FIELD_NAME, 'a', indexOption)
                         .withPayload("payload".getBytes())
         );
 
@@ -90,6 +94,22 @@ public class FieldValueExtractionTest {
         final DocumentProvider db = build(IndexOption.STORED);
         final long storedValue = from(25).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
         assertEquals(storedValue, db.getIntValue(0, INT_FIELD_NAME));
+    }
+
+    @Test
+    public void extractStoredShort() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        final short sv = 25;
+        final long storedValue = from(sv).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+        assertEquals(storedValue, db.getShortValue(0, SHORT_FIELD_NAME));
+    }
+
+    @Test
+    public void extractStoredChar() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        final char cv = 'a';
+        final long storedValue = from(cv).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+        assertEquals(storedValue, db.getCharValue(0, CHAR_FIELD_NAME));
     }
 
     @Test(expected = AssertionError.class)

--- a/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
@@ -34,6 +34,12 @@ public class FieldValueExtractionTest {
     private static final String SHORT_FIELD_NAME = "short_id";
     private static final String CHAR_FIELD_NAME = "char_id";
 
+    private static final int INT_FIELD_VALUE = 25;
+    private static final long LONG_FIELD_VALUE = 25L;
+    private static final short SHORT_FIELD_VALUE = 25;
+    private static final char CHAR_FIELD_VALUE = 'a';
+
+
     private DocumentProvider build(
             final IndexOption indexOption) throws IOException {
         final DatabaseBuilder dbBuilder =
@@ -47,10 +53,10 @@ public class FieldValueExtractionTest {
                                 FIELD_NAME,
                                 0,
                                 indexOption)
-                        .withField(INT_FIELD_NAME, 25, indexOption)
-                        .withField(LONG_FIELD_NAME, 25L, indexOption)
-                        .withField(SHORT_FIELD_NAME, (short) 25, indexOption)
-                        .withField(CHAR_FIELD_NAME, 'a', indexOption)
+                        .withField(INT_FIELD_NAME, INT_FIELD_VALUE, indexOption)
+                        .withField(LONG_FIELD_NAME, LONG_FIELD_VALUE, indexOption)
+                        .withField(SHORT_FIELD_NAME, SHORT_FIELD_VALUE, indexOption)
+                        .withField(CHAR_FIELD_NAME, CHAR_FIELD_VALUE, indexOption)
                         .withPayload("payload".getBytes())
         );
 
@@ -85,31 +91,29 @@ public class FieldValueExtractionTest {
     @Test
     public void extractStoredLong() throws IOException {
         final DocumentProvider db = build(IndexOption.STORED);
-        final long storedValue = from(25L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
-        assertEquals(storedValue, db.getLongValue(0, LONG_FIELD_NAME));
+        final long storedValue = db.getLongValue(0, LONG_FIELD_NAME);
+        assertEquals(LONG_FIELD_VALUE, storedValue);
     }
 
     @Test
     public void extractStoredInt() throws IOException {
         final DocumentProvider db = build(IndexOption.STORED);
-        final long storedValue = from(25).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
-        assertEquals(storedValue, db.getIntValue(0, INT_FIELD_NAME));
+        final int storedValue = db.getIntValue(0, INT_FIELD_NAME);
+        assertEquals(INT_FIELD_VALUE, storedValue);
     }
 
     @Test
     public void extractStoredShort() throws IOException {
         final DocumentProvider db = build(IndexOption.STORED);
-        final short sv = 25;
-        final long storedValue = from(sv).toByteBuffer().getShort() ^ Short.MIN_VALUE;
-        assertEquals(storedValue, db.getShortValue(0, SHORT_FIELD_NAME));
+        final short storedValue = db.getShortValue(0, SHORT_FIELD_NAME);
+        assertEquals(SHORT_FIELD_VALUE, storedValue);
     }
 
     @Test
     public void extractStoredChar() throws IOException {
         final DocumentProvider db = build(IndexOption.STORED);
-        final char cv = 'a';
-        final long storedValue = from(cv).toByteBuffer().getChar() ^ Character.MIN_VALUE;
-        assertEquals(storedValue, db.getCharValue(0, CHAR_FIELD_NAME));
+        final char storedValue = db.getCharValue(0, CHAR_FIELD_NAME);
+        assertEquals(CHAR_FIELD_VALUE, storedValue);
     }
 
     @Test(expected = AssertionError.class)

--- a/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FieldValueExtractionTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class FieldValueExtractionTest {
     private static final String FIELD_NAME = "id";
+    private static final String INT_FIELD_NAME = "int_id";
+    private static final String LONG_FIELD_NAME = "long_id";
 
     private DocumentProvider build(
             final IndexOption indexOption) throws IOException {
@@ -43,6 +45,8 @@ public class FieldValueExtractionTest {
                                 FIELD_NAME,
                                 0,
                                 indexOption)
+                        .withField(INT_FIELD_NAME, 25, indexOption)
+                        .withField(LONG_FIELD_NAME, 25L, indexOption)
                         .withPayload("payload".getBytes())
         );
 
@@ -66,6 +70,26 @@ public class FieldValueExtractionTest {
         final DocumentProvider db = build(IndexOption.SORTABLE);
 
         assertEquals(from(0).toByteBuffer(), db.getFieldValue(0, FIELD_NAME));
+    }
+
+    @Test
+    public void extractStoredFieldValue() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        assertEquals(from(0).toByteBuffer(), db.getFieldValue(0, FIELD_NAME));
+    }
+
+    @Test
+    public void extractStoredLong() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        final long storedValue = from(25L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+        assertEquals(storedValue, db.getLongValue(0, LONG_FIELD_NAME));
+    }
+
+    @Test
+    public void extractStoredInt() throws IOException {
+        final DocumentProvider db = build(IndexOption.STORED);
+        final long storedValue = from(25).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+        assertEquals(storedValue, db.getIntValue(0, INT_FIELD_NAME));
     }
 
     @Test(expected = AssertionError.class)

--- a/core/src/test/java/com/yandex/yoctodb/FoldedIndexTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FoldedIndexTest.java
@@ -31,17 +31,35 @@ public class FoldedIndexTest {
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "NEW", STORED));
+                        .withField("state", "NEW", STORED)
+                        .withField("byte", (byte) 1, STORED)
+                        .withField("short", (short) 1, STORED)
+                        .withField("int", 1, STORED)
+                        .withField("long", 1L, STORED)
+                        .withField("char", 'a', STORED)
+        );
         dbBuilder.merge(
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "USED", STORED));
+                        .withField("state", "USED", STORED)
+                        .withField("byte", (byte) 2, STORED)
+                        .withField("short", (short) 2, STORED)
+                        .withField("int", 2, STORED)
+                        .withField("long", 2L, STORED)
+                        .withField("char", 'b', STORED)
+        );
         dbBuilder.merge(
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "NEW", STORED));
+                        .withField("state", "NEW", STORED)
+                        .withField("byte", (byte) 1, STORED)
+                        .withField("short", (short) 1, STORED)
+                        .withField("int", 1, STORED)
+                        .withField("long", 1L, STORED)
+                        .withField("char", 'a', STORED)
+        );
 
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
         dbBuilder.buildWritable().writeTo(os);
@@ -51,9 +69,31 @@ public class FoldedIndexTest {
                         .getDatabaseReader()
                         .from(Buffer.from(os.toByteArray()));
 
-        assertEquals("NEW",getValueFromBuffer(db.getFieldValue(0, "state")));
-        assertEquals("USED",getValueFromBuffer(db.getFieldValue(1, "state")));
-        assertEquals("NEW",getValueFromBuffer(db.getFieldValue(2, "state")));
+        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(0, "state")));
+        assertEquals("USED", getValueFromBuffer(db.getFieldValue(1, "state")));
+        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(2, "state")));
+
+        assertEquals((byte) 1, db.getByteValue(0, "byte"));
+        assertEquals((byte) 2, db.getByteValue(1, "byte"));
+        assertEquals((byte) 1, db.getByteValue(2, "byte"));
+
+        assertEquals((short) 1, db.getShortValue(0, "short"));
+        assertEquals((short) 2, db.getShortValue(1, "short"));
+        assertEquals((short) 1, db.getShortValue(2, "short"));
+
+        assertEquals(1, db.getIntValue(0, "int"));
+        assertEquals(2, db.getIntValue(1, "int"));
+        assertEquals(1, db.getIntValue(2, "int"));
+
+        assertEquals(1L, db.getLongValue(0, "long"));
+        assertEquals(2L, db.getLongValue(1, "long"));
+        assertEquals(1L, db.getLongValue(2, "long"));
+
+        assertEquals('a', db.getCharValue(0, "char"));
+        assertEquals('b', db.getCharValue(1, "char"));
+        assertEquals('a', db.getCharValue(2, "char"));
+
+
     }
 
     private String getValueFromBuffer(Buffer buffer) {

--- a/core/src/test/java/com/yandex/yoctodb/FoldedIndexTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FoldedIndexTest.java
@@ -1,3 +1,13 @@
+/*
+ * (C) YANDEX LLC, 2014-2019
+ *
+ * The Source Code called "YoctoDB" available at
+ * https://github.com/yandex/yoctodb is subject to the terms of the
+ * Mozilla Public License, v. 2.0 (hereinafter referred to as the "License").
+ *
+ * A copy of the License is also available at http://mozilla.org/MPL/2.0/.
+ */
+
 package com.yandex.yoctodb;
 
 import com.yandex.yoctodb.immutable.Database;
@@ -21,6 +31,13 @@ import static org.junit.Assert.assertEquals;
  */
 public class FoldedIndexTest {
 
+    String BYTE_FIELD_NAME = "byte";
+    String SHORT_FIELD_NAME = "short";
+    String INT_FIELD_NAME = "int";
+    String LONG_FIELD_NAME = "long";
+    String CHAR_FIELD_NAME = "char";
+    String STATE_FIELD_NAME = "state";
+
     @Test
     public void buildDatabase() throws IOException {
         final DatabaseBuilder dbBuilder =
@@ -31,34 +48,36 @@ public class FoldedIndexTest {
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "NEW", STORED)
-                        .withField("byte", (byte) 1, STORED)
-                        .withField("short", (short) 1, STORED)
-                        .withField("int", 1, STORED)
-                        .withField("long", 1L, STORED)
-                        .withField("char", 'a', STORED)
+                        .withField(STATE_FIELD_NAME, "NEW", STORED)
+                        .withField(BYTE_FIELD_NAME, (byte) 1, STORED)
+                        .withField(SHORT_FIELD_NAME, (short) 1, STORED)
+                        .withField(INT_FIELD_NAME, 1, STORED)
+                        .withField(LONG_FIELD_NAME, 1L, STORED)
+                        .withField(CHAR_FIELD_NAME, 'a', STORED)
         );
+        // Document 2
         dbBuilder.merge(
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "USED", STORED)
-                        .withField("byte", (byte) 2, STORED)
-                        .withField("short", (short) 2, STORED)
-                        .withField("int", 2, STORED)
-                        .withField("long", 2L, STORED)
-                        .withField("char", 'b', STORED)
+                        .withField(STATE_FIELD_NAME, "USED", STORED)
+                        .withField(BYTE_FIELD_NAME, (byte) 2, STORED)
+                        .withField(SHORT_FIELD_NAME, (short) 2, STORED)
+                        .withField(INT_FIELD_NAME, 2, STORED)
+                        .withField(LONG_FIELD_NAME, 2L, STORED)
+                        .withField(CHAR_FIELD_NAME, 'b', STORED)
         );
+        // Document 3
         dbBuilder.merge(
                 DatabaseFormat
                         .getCurrent()
                         .newDocumentBuilder()
-                        .withField("state", "NEW", STORED)
-                        .withField("byte", (byte) 1, STORED)
-                        .withField("short", (short) 1, STORED)
-                        .withField("int", 1, STORED)
-                        .withField("long", 1L, STORED)
-                        .withField("char", 'a', STORED)
+                        .withField(STATE_FIELD_NAME, "NEW", STORED)
+                        .withField(BYTE_FIELD_NAME, (byte) 1, STORED)
+                        .withField(SHORT_FIELD_NAME, (short) 1, STORED)
+                        .withField(INT_FIELD_NAME, 1, STORED)
+                        .withField(LONG_FIELD_NAME, 1L, STORED)
+                        .withField(CHAR_FIELD_NAME, 'a', STORED)
         );
 
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -69,29 +88,29 @@ public class FoldedIndexTest {
                         .getDatabaseReader()
                         .from(Buffer.from(os.toByteArray()));
 
-        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(0, "state")));
-        assertEquals("USED", getValueFromBuffer(db.getFieldValue(1, "state")));
-        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(2, "state")));
+        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(0, STATE_FIELD_NAME)));
+        assertEquals("USED", getValueFromBuffer(db.getFieldValue(1, STATE_FIELD_NAME)));
+        assertEquals("NEW", getValueFromBuffer(db.getFieldValue(2, STATE_FIELD_NAME)));
 
-        assertEquals((byte) 1, db.getByteValue(0, "byte"));
-        assertEquals((byte) 2, db.getByteValue(1, "byte"));
-        assertEquals((byte) 1, db.getByteValue(2, "byte"));
+        assertEquals((byte) 1, db.getByteValue(0, BYTE_FIELD_NAME));
+        assertEquals((byte) 2, db.getByteValue(1, BYTE_FIELD_NAME));
+        assertEquals((byte) 1, db.getByteValue(2, BYTE_FIELD_NAME));
 
-        assertEquals((short) 1, db.getShortValue(0, "short"));
-        assertEquals((short) 2, db.getShortValue(1, "short"));
-        assertEquals((short) 1, db.getShortValue(2, "short"));
+        assertEquals((short) 1, db.getShortValue(0, SHORT_FIELD_NAME));
+        assertEquals((short) 2, db.getShortValue(1, SHORT_FIELD_NAME));
+        assertEquals((short) 1, db.getShortValue(2, SHORT_FIELD_NAME));
 
-        assertEquals(1, db.getIntValue(0, "int"));
-        assertEquals(2, db.getIntValue(1, "int"));
-        assertEquals(1, db.getIntValue(2, "int"));
+        assertEquals(1, db.getIntValue(0, INT_FIELD_NAME));
+        assertEquals(2, db.getIntValue(1, INT_FIELD_NAME));
+        assertEquals(1, db.getIntValue(2, INT_FIELD_NAME));
 
-        assertEquals(1L, db.getLongValue(0, "long"));
-        assertEquals(2L, db.getLongValue(1, "long"));
-        assertEquals(1L, db.getLongValue(2, "long"));
+        assertEquals(1L, db.getLongValue(0, LONG_FIELD_NAME));
+        assertEquals(2L, db.getLongValue(1, LONG_FIELD_NAME));
+        assertEquals(1L, db.getLongValue(2, LONG_FIELD_NAME));
 
-        assertEquals('a', db.getCharValue(0, "char"));
-        assertEquals('b', db.getCharValue(1, "char"));
-        assertEquals('a', db.getCharValue(2, "char"));
+        assertEquals('a', db.getCharValue(0, CHAR_FIELD_NAME));
+        assertEquals('b', db.getCharValue(1, CHAR_FIELD_NAME));
+        assertEquals('a', db.getCharValue(2, CHAR_FIELD_NAME));
 
 
     }

--- a/core/src/test/java/com/yandex/yoctodb/FoldedIndexWithEmptyTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/FoldedIndexWithEmptyTest.java
@@ -1,3 +1,13 @@
+/*
+ * (C) YANDEX LLC, 2014-2019
+ *
+ * The Source Code called "YoctoDB" available at
+ * https://github.com/yandex/yoctodb is subject to the terms of the
+ * Mozilla Public License, v. 2.0 (hereinafter referred to as the "License").
+ *
+ * A copy of the License is also available at http://mozilla.org/MPL/2.0/.
+ */
+
 package com.yandex.yoctodb;
 
 import com.yandex.yoctodb.immutable.Database;

--- a/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
@@ -10,25 +10,40 @@
 
 package com.yandex.yoctodb;
 
-import com.google.common.primitives.Ints;
 import com.yandex.yoctodb.immutable.Database;
 import com.yandex.yoctodb.mutable.DatabaseBuilder;
 import com.yandex.yoctodb.query.DocumentProcessor;
 import com.yandex.yoctodb.query.Query;
 import com.yandex.yoctodb.query.simple.SimpleDescendingOrder;
 import com.yandex.yoctodb.query.simple.SimpleRangeCondition;
-import com.yandex.yoctodb.util.UnsignedByteArrays;
 import com.yandex.yoctodb.util.buf.Buffer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption.*;
-import static com.yandex.yoctodb.query.QueryBuilder.*;
+import static com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption.FILTERABLE;
+import static com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption.FULL;
+import static com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption.SORTABLE;
+import static com.yandex.yoctodb.mutable.DocumentBuilder.IndexOption.STORED;
+import static com.yandex.yoctodb.query.QueryBuilder.asc;
+import static com.yandex.yoctodb.query.QueryBuilder.desc;
+import static com.yandex.yoctodb.query.QueryBuilder.eq;
+import static com.yandex.yoctodb.query.QueryBuilder.gt;
+import static com.yandex.yoctodb.query.QueryBuilder.gte;
+import static com.yandex.yoctodb.query.QueryBuilder.in;
+import static com.yandex.yoctodb.query.QueryBuilder.lt;
+import static com.yandex.yoctodb.query.QueryBuilder.lte;
+import static com.yandex.yoctodb.query.QueryBuilder.not;
+import static com.yandex.yoctodb.query.QueryBuilder.or;
+import static com.yandex.yoctodb.query.QueryBuilder.select;
 import static com.yandex.yoctodb.util.UnsignedByteArrays.from;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -435,6 +450,12 @@ public class SimpleDatabaseTest {
                         .withField("sorted", 12, SORTABLE)
                         .withField("stored", 13, STORED)
                         .withField("first", 14, STORED)
+                        .withField("long_stored", 15L, STORED)
+                        .withField("int_stored", 16, STORED)
+                        .withField("long_full", 15L, FULL)
+                        .withField("int_full", 16, FULL)
+                        .withField("long_sortable", 15L, SORTABLE)
+                        .withField("int_sortable", 16, SORTABLE)
                         .withPayload(("payload1").getBytes())
         );
 
@@ -464,6 +485,24 @@ public class SimpleDatabaseTest {
         assertEquals(from(14).toByteBuffer(), db.getFieldValue(0, "first"));
         assertEquals(from("payload1").toByteBuffer(), db.getDocument(0));
         assertFalse(db.getFieldValue(0, "second").hasRemaining());
+
+        final long puttedLongValueStored = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+        assertEquals(puttedLongValueStored, db.getLongValue(0, "long_stored"));
+
+        final int puttedIntValueStored = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+        assertEquals(puttedIntValueStored, db.getIntValue(0, "int_stored"));
+
+        final long puttedLongValueFull = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+        assertEquals(puttedLongValueFull, db.getLongValue(0, "long_full"));
+
+        final int puttedIntValueFull = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+        assertEquals(puttedIntValueFull, db.getIntValue(0, "int_full"));
+
+        final long puttedLongValueSortable = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+        assertEquals(puttedLongValueSortable, db.getLongValue(0, "long_sortable"));
+
+        final int puttedIntValueSortable = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+        assertEquals(puttedIntValueSortable, db.getIntValue(0, "int_sortable"));
 
         // Document 2
 

--- a/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
@@ -77,6 +77,11 @@ public class SimpleDatabaseTest {
     private final String CHAR_SORTABLE_FIELD_NAME = "char_sortable";
     private final char CHAR_FIELD_VALUE = 'a';
 
+    private final String BYTE_STORED_FIELD_NAME = "byte_stored";
+    private final String BYTE_FULL_FIELD_NAME = "byte_full";
+    private final String BYTE_SORTABLE_FIELD_NAME = "byte_sortable";
+    private final byte BYTE_FIELD_VALUE = -128;
+
     @Test
     public void buildDatabase() throws IOException {
         final DatabaseBuilder dbBuilder =
@@ -487,6 +492,10 @@ public class SimpleDatabaseTest {
                         .withField(CHAR_FULL_FIELD_NAME, CHAR_FIELD_VALUE, FULL)
                         .withField(CHAR_SORTABLE_FIELD_NAME, CHAR_FIELD_VALUE, SORTABLE)
 
+                        .withField(BYTE_STORED_FIELD_NAME, BYTE_FIELD_VALUE, STORED)
+                        .withField(BYTE_FULL_FIELD_NAME, BYTE_FIELD_VALUE, FULL)
+                        .withField(BYTE_SORTABLE_FIELD_NAME, BYTE_FIELD_VALUE, SORTABLE)
+
                         .withPayload(("payload1").getBytes())
         );
 
@@ -532,6 +541,10 @@ public class SimpleDatabaseTest {
         assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_STORED_FIELD_NAME));
         assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_FULL_FIELD_NAME));
         assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_SORTABLE_FIELD_NAME));
+
+        assertEquals(BYTE_FIELD_VALUE, db.getByteValue(0, BYTE_STORED_FIELD_NAME));
+        assertEquals(BYTE_FIELD_VALUE, db.getByteValue(0, BYTE_FULL_FIELD_NAME));
+        assertEquals(BYTE_FIELD_VALUE, db.getByteValue(0, BYTE_SORTABLE_FIELD_NAME));
 
         // Document 2
 

--- a/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
@@ -456,6 +456,12 @@ public class SimpleDatabaseTest {
                         .withField("int_full", 16, FULL)
                         .withField("long_sortable", 15L, SORTABLE)
                         .withField("int_sortable", 16, SORTABLE)
+                        .withField("short_stored", (short) 15, STORED)
+                        .withField("char_stored", 'a', STORED)
+                        .withField("short_full", (short) 15, FULL)
+                        .withField("char_full", 'a', FULL)
+                        .withField("short_sortable", (short) 15, SORTABLE)
+                        .withField("char_sortable", 'a', SORTABLE)
                         .withPayload(("payload1").getBytes())
         );
 
@@ -503,6 +509,24 @@ public class SimpleDatabaseTest {
 
         final int puttedIntValueSortable = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
         assertEquals(puttedIntValueSortable, db.getIntValue(0, "int_sortable"));
+
+        final long puttedShortValueStored = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+        assertEquals(puttedShortValueStored, db.getShortValue(0, "short_stored"));
+
+        final int puttedCharValueStored = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
+        assertEquals(puttedCharValueStored, db.getCharValue(0, "char_stored"));
+
+        final long puttedShortValueFull = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+        assertEquals(puttedShortValueFull, db.getShortValue(0, "short_full"));
+
+        final int puttedCharValueFull = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
+        assertEquals(puttedCharValueFull, db.getCharValue(0, "char_full"));
+
+        final long puttedShortValueSortable = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+        assertEquals(puttedShortValueSortable, db.getShortValue(0, "short_sortable"));
+
+        final int puttedCharValueSortable = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
+        assertEquals(puttedCharValueSortable, db.getCharValue(0, "char_sortable"));
 
         // Document 2
 

--- a/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/SimpleDatabaseTest.java
@@ -57,6 +57,26 @@ import static org.junit.Assert.assertTrue;
 public class SimpleDatabaseTest {
     private final int DOCS = 128;
 
+    private final String LONG_STORED_FIELD_NAME = "long_stored";
+    private final String LONG_FULL_FIELD_NAME = "long_full";
+    private final String LONG_SORTABLE_FIELD_NAME = "long_sortable";
+    private final long LONG_FIELD_VALUE = 25L;
+
+    private final String INT_STORED_FIELD_NAME = "int_stored";
+    private final String INT_FULL_FIELD_NAME = "int_full";
+    private final String INT_SORTABLE_FIELD_NAME = "int_sortable";
+    private final int INT_FIELD_VALUE = 15;
+
+    private final String SHORT_STORED_FIELD_NAME = "short_stored";
+    private final String SHORT_FULL_FIELD_NAME = "short_full";
+    private final String SHORT_SORTABLE_FIELD_NAME = "short_sortable";
+    private final short SHORT_FIELD_VALUE = 13;
+
+    private final String CHAR_STORED_FIELD_NAME = "char_stored";
+    private final String CHAR_FULL_FIELD_NAME = "char_full";
+    private final String CHAR_SORTABLE_FIELD_NAME = "char_sortable";
+    private final char CHAR_FIELD_VALUE = 'a';
+
     @Test
     public void buildDatabase() throws IOException {
         final DatabaseBuilder dbBuilder =
@@ -450,18 +470,23 @@ public class SimpleDatabaseTest {
                         .withField("sorted", 12, SORTABLE)
                         .withField("stored", 13, STORED)
                         .withField("first", 14, STORED)
-                        .withField("long_stored", 15L, STORED)
-                        .withField("int_stored", 16, STORED)
-                        .withField("long_full", 15L, FULL)
-                        .withField("int_full", 16, FULL)
-                        .withField("long_sortable", 15L, SORTABLE)
-                        .withField("int_sortable", 16, SORTABLE)
-                        .withField("short_stored", (short) 15, STORED)
-                        .withField("char_stored", 'a', STORED)
-                        .withField("short_full", (short) 15, FULL)
-                        .withField("char_full", 'a', FULL)
-                        .withField("short_sortable", (short) 15, SORTABLE)
-                        .withField("char_sortable", 'a', SORTABLE)
+
+                        .withField(LONG_STORED_FIELD_NAME, LONG_FIELD_VALUE, STORED)
+                        .withField(LONG_FULL_FIELD_NAME, LONG_FIELD_VALUE, FULL)
+                        .withField(LONG_SORTABLE_FIELD_NAME, LONG_FIELD_VALUE, SORTABLE)
+
+                        .withField(INT_STORED_FIELD_NAME, INT_FIELD_VALUE, STORED)
+                        .withField(INT_FULL_FIELD_NAME, INT_FIELD_VALUE, FULL)
+                        .withField(INT_SORTABLE_FIELD_NAME, INT_FIELD_VALUE, SORTABLE)
+
+                        .withField(SHORT_STORED_FIELD_NAME, SHORT_FIELD_VALUE, STORED)
+                        .withField(SHORT_FULL_FIELD_NAME, SHORT_FIELD_VALUE, FULL)
+                        .withField(SHORT_SORTABLE_FIELD_NAME, SHORT_FIELD_VALUE, SORTABLE)
+
+                        .withField(CHAR_STORED_FIELD_NAME, CHAR_FIELD_VALUE, STORED)
+                        .withField(CHAR_FULL_FIELD_NAME, CHAR_FIELD_VALUE, FULL)
+                        .withField(CHAR_SORTABLE_FIELD_NAME, CHAR_FIELD_VALUE, SORTABLE)
+
                         .withPayload(("payload1").getBytes())
         );
 
@@ -492,41 +517,21 @@ public class SimpleDatabaseTest {
         assertEquals(from("payload1").toByteBuffer(), db.getDocument(0));
         assertFalse(db.getFieldValue(0, "second").hasRemaining());
 
-        final long puttedLongValueStored = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
-        assertEquals(puttedLongValueStored, db.getLongValue(0, "long_stored"));
+        assertEquals(LONG_FIELD_VALUE, db.getLongValue(0, LONG_STORED_FIELD_NAME));
+        assertEquals(LONG_FIELD_VALUE, db.getLongValue(0, LONG_FULL_FIELD_NAME));
+        assertEquals(LONG_FIELD_VALUE, db.getLongValue(0, LONG_SORTABLE_FIELD_NAME));
 
-        final int puttedIntValueStored = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
-        assertEquals(puttedIntValueStored, db.getIntValue(0, "int_stored"));
+        assertEquals(INT_FIELD_VALUE, db.getIntValue(0, INT_STORED_FIELD_NAME));
+        assertEquals(INT_FIELD_VALUE, db.getIntValue(0, INT_FULL_FIELD_NAME));
+        assertEquals(INT_FIELD_VALUE, db.getIntValue(0, INT_SORTABLE_FIELD_NAME));
 
-        final long puttedLongValueFull = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
-        assertEquals(puttedLongValueFull, db.getLongValue(0, "long_full"));
+        assertEquals(SHORT_FIELD_VALUE, db.getShortValue(0, SHORT_STORED_FIELD_NAME));
+        assertEquals(SHORT_FIELD_VALUE, db.getShortValue(0, SHORT_FULL_FIELD_NAME));
+        assertEquals(SHORT_FIELD_VALUE, db.getShortValue(0, SHORT_SORTABLE_FIELD_NAME));
 
-        final int puttedIntValueFull = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
-        assertEquals(puttedIntValueFull, db.getIntValue(0, "int_full"));
-
-        final long puttedLongValueSortable = from(15L).toByteBuffer().getLong() ^ Long.MIN_VALUE;
-        assertEquals(puttedLongValueSortable, db.getLongValue(0, "long_sortable"));
-
-        final int puttedIntValueSortable = from(16).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
-        assertEquals(puttedIntValueSortable, db.getIntValue(0, "int_sortable"));
-
-        final long puttedShortValueStored = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
-        assertEquals(puttedShortValueStored, db.getShortValue(0, "short_stored"));
-
-        final int puttedCharValueStored = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
-        assertEquals(puttedCharValueStored, db.getCharValue(0, "char_stored"));
-
-        final long puttedShortValueFull = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
-        assertEquals(puttedShortValueFull, db.getShortValue(0, "short_full"));
-
-        final int puttedCharValueFull = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
-        assertEquals(puttedCharValueFull, db.getCharValue(0, "char_full"));
-
-        final long puttedShortValueSortable = from((short) 15).toByteBuffer().getShort() ^ Short.MIN_VALUE;
-        assertEquals(puttedShortValueSortable, db.getShortValue(0, "short_sortable"));
-
-        final int puttedCharValueSortable = from('a').toByteBuffer().getChar() ^ Character.MIN_VALUE;
-        assertEquals(puttedCharValueSortable, db.getCharValue(0, "char_sortable"));
+        assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_STORED_FIELD_NAME));
+        assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_FULL_FIELD_NAME));
+        assertEquals(CHAR_FIELD_VALUE, db.getCharValue(0, CHAR_SORTABLE_FIELD_NAME));
 
         // Document 2
 

--- a/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
@@ -70,6 +70,11 @@ public class IdScoredDocumentTest {
                 }
 
                 @Override
+                public byte getByteValue(int document, @NotNull String fieldName) {
+                    throw new IllegalArgumentException();
+                }
+
+                @Override
                 public void execute(
                         @NotNull
                         final Query query,

--- a/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
@@ -50,6 +50,16 @@ public class IdScoredDocumentTest {
                 }
 
                 @Override
+                public long getLongValue(int document, @NotNull String fieldName) {
+                    throw new IllegalStateException();
+                }
+
+                @Override
+                public int getIntValue(int document, @NotNull String fieldName) {
+                    throw new IllegalArgumentException();
+                }
+
+                @Override
                 public void execute(
                         @NotNull
                         final Query query,

--- a/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/query/simple/IdScoredDocumentTest.java
@@ -60,6 +60,16 @@ public class IdScoredDocumentTest {
                 }
 
                 @Override
+                public short getShortValue(int document, @NotNull String fieldName) {
+                    throw new IllegalArgumentException();
+                }
+
+                @Override
+                public char getCharValue(int document, @NotNull String fieldName) {
+                    throw new IllegalArgumentException();
+                }
+
+                @Override
                 public void execute(
                         @NotNull
                         final Query query,

--- a/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
@@ -152,4 +152,40 @@ public class FileChannelBufferTest extends BufferTest {
                 .thenThrow(new IOException("Test"));
         new FileChannelBuffer(broken).getLong(0L);
     }
+
+    @Test(expected = RuntimeException.class)
+    public void getShort() throws IOException {
+        final FileChannel broken = mock(FileChannel.class);
+        when(broken.size()).thenReturn(1024L);
+        when(broken.read(any(ByteBuffer.class), anyLong()))
+                .thenThrow(new IOException("Test"));
+        new FileChannelBuffer(broken).getShort();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getShortByIndex() throws IOException {
+        final FileChannel broken = mock(FileChannel.class);
+        when(broken.size()).thenReturn(1024L);
+        when(broken.read(any(ByteBuffer.class), anyLong()))
+                .thenThrow(new IOException("Test"));
+        new FileChannelBuffer(broken).getShort(0L);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getChar() throws IOException {
+        final FileChannel broken = mock(FileChannel.class);
+        when(broken.size()).thenReturn(1024L);
+        when(broken.read(any(ByteBuffer.class), anyLong()))
+                .thenThrow(new IOException("Test"));
+        new FileChannelBuffer(broken).getChar();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getCharByIndex() throws IOException {
+        final FileChannel broken = mock(FileChannel.class);
+        when(broken.size()).thenReturn(1024L);
+        when(broken.read(any(ByteBuffer.class), anyLong()))
+                .thenThrow(new IOException("Test"));
+        new FileChannelBuffer(broken).getChar(0L);
+    }
 }

--- a/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
@@ -10,6 +10,8 @@
 
 package com.yandex.yoctodb.util.buf;
 
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Shorts;
 import org.junit.Test;
 
 import java.io.File;
@@ -19,7 +21,12 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicInteger;
-import static org.mockito.Mockito.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests in {@link com.yandex.yoctodb.util.buf.FileChannelBuffer}
@@ -154,7 +161,7 @@ public class FileChannelBufferTest extends BufferTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void getShort() throws IOException {
+    public void getShortBroken() throws IOException {
         final FileChannel broken = mock(FileChannel.class);
         when(broken.size()).thenReturn(1024L);
         when(broken.read(any(ByteBuffer.class), anyLong()))
@@ -163,7 +170,7 @@ public class FileChannelBufferTest extends BufferTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void getShortByIndex() throws IOException {
+    public void getShortByIndexBroken() throws IOException {
         final FileChannel broken = mock(FileChannel.class);
         when(broken.size()).thenReturn(1024L);
         when(broken.read(any(ByteBuffer.class), anyLong()))
@@ -172,7 +179,7 @@ public class FileChannelBufferTest extends BufferTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void getChar() throws IOException {
+    public void getCharBroken() throws IOException {
         final FileChannel broken = mock(FileChannel.class);
         when(broken.size()).thenReturn(1024L);
         when(broken.read(any(ByteBuffer.class), anyLong()))
@@ -181,11 +188,67 @@ public class FileChannelBufferTest extends BufferTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void getCharByIndex() throws IOException {
+    public void getCharByIndexBroken() throws IOException {
         final FileChannel broken = mock(FileChannel.class);
         when(broken.size()).thenReturn(1024L);
         when(broken.read(any(ByteBuffer.class), anyLong()))
                 .thenThrow(new IOException("Test"));
         new FileChannelBuffer(broken).getChar(0L);
+    }
+
+    @Test
+    public void getShort() throws IOException {
+        final short snum = 123;
+        final byte[] bytes = Shorts.toByteArray(snum);
+        final Path path = nextTempFile(bytes);
+        final FileChannel read = FileChannel.open(
+                path,
+                StandardOpenOption.READ,
+                StandardOpenOption.DELETE_ON_CLOSE);
+        final Buffer buf = Buffer.from(read);
+
+        assertEquals(snum, buf.getShort());
+    }
+
+    @Test
+    public void getShortByIndex() throws IOException {
+        final short snum = 123;
+        final byte[] bytes = Shorts.toByteArray(snum);
+        final Path path = nextTempFile(bytes);
+        final FileChannel read = FileChannel.open(
+                path,
+                StandardOpenOption.READ,
+                StandardOpenOption.DELETE_ON_CLOSE);
+        final Buffer buf = Buffer.from(read);
+
+        assertEquals(snum, buf.getShort(0));
+    }
+
+    @Test
+    public void getChar() throws IOException {
+        final char ch = 'a';
+        final byte[] bytes = Chars.toByteArray(ch);
+        final Path path = nextTempFile(bytes);
+        final FileChannel read = FileChannel.open(
+                path,
+                StandardOpenOption.READ,
+                StandardOpenOption.DELETE_ON_CLOSE);
+        final Buffer buf = Buffer.from(read);
+
+        assertEquals(ch, buf.getChar());
+    }
+
+    @Test
+    public void getCharByIndex() throws IOException {
+        final char ch = 'a';
+        final byte[] bytes = Chars.toByteArray(ch);
+        final Path path = nextTempFile(bytes);
+        final FileChannel read = FileChannel.open(
+                path,
+                StandardOpenOption.READ,
+                StandardOpenOption.DELETE_ON_CLOSE);
+        final Buffer buf = Buffer.from(read);
+
+        assertEquals(ch, buf.getChar(0));
     }
 }

--- a/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/buf/FileChannelBufferTest.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -53,6 +53,54 @@ public class ByteArrayIndexedListTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArrayIndexedListTestLongUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0L));
+        elements.add(UnsignedByteArrays.from(1L));
+        elements.add(UnsignedByteArrays.from(2L));
+        elements.add(UnsignedByteArrays.from(3L));
+        elements.add(UnsignedByteArrays.from(4L));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArrayIndexedList(elements);
+        final ByteArrayIndexedList list =
+                FixedLengthByteArrayIndexedList.from(bb);
+
+        Assert.assertEquals(elements.size(), list.size());
+
+        for (int i = 0; i < elements.size(); ++i) {
+            final long puttedValue = elements.get(i).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getLongUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromFixedLengthByteArrayIndexedListTestIntUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0));
+        elements.add(UnsignedByteArrays.from(1));
+        elements.add(UnsignedByteArrays.from(2));
+        elements.add(UnsignedByteArrays.from(3));
+        elements.add(UnsignedByteArrays.from(4));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArrayIndexedList(elements);
+        final ByteArrayIndexedList list =
+                FixedLengthByteArrayIndexedList.from(bb);
+
+        Assert.assertEquals(elements.size(), list.size());
+
+        for (int i = 0; i < elements.size(); ++i) {
+            final long puttedValue = elements.get(i).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getIntUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArrayIndexedList(
             final Collection<UnsignedByteArray> elements) throws IOException {
         final com.yandex.yoctodb.util.mutable.impl.FixedLengthByteArrayIndexedList fixedLengthByteArrayIndexedList =
@@ -66,6 +114,7 @@ public class ByteArrayIndexedListTest {
 
         return Buffer.from(os.toByteArray());
     }
+
 
     @Test
     public void buildingFromVariableLengthByteArrayIndexedListTest()
@@ -87,6 +136,50 @@ public class ByteArrayIndexedListTest {
             Assert.assertEquals(
                     elements.get(i).toByteBuffer(),
                     list.get(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArrayIndexedListTestLongUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0L));
+        elements.add(UnsignedByteArrays.from(1L));
+        elements.add(UnsignedByteArrays.from(2L));
+        elements.add(UnsignedByteArrays.from(3L));
+        elements.add(UnsignedByteArrays.from(4L));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArrayIndexedLength(elements);
+        final ByteArrayIndexedList list =
+                VariableLengthByteArrayIndexedList.from(bb);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getLongUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArrayIndexedListTestIntUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0));
+        elements.add(UnsignedByteArrays.from(1));
+        elements.add(UnsignedByteArrays.from(2));
+        elements.add(UnsignedByteArrays.from(3));
+        elements.add(UnsignedByteArrays.from(4));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArrayIndexedLength(elements);
+        final ByteArrayIndexedList list =
+                VariableLengthByteArrayIndexedList.from(bb);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getIntUnsafe(i));
         }
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -163,7 +163,6 @@ public class ByteArrayIndexedListTest {
         return Buffer.from(os.toByteArray());
     }
 
-
     @Test
     public void buildingFromVariableLengthByteArrayIndexedListTest()
             throws IOException {

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -144,7 +144,7 @@ public class ByteArrayIndexedListTest {
         Assert.assertEquals(elements.size(), list.size());
 
         for (int i = 0; i < elements.size(); ++i) {
-            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            final long puttedValue = elements.get(i).toByteBuffer().getChar();
             Assert.assertEquals(puttedValue, list.getCharUnsafe(i));
         }
     }
@@ -269,7 +269,7 @@ public class ByteArrayIndexedListTest {
                 VariableLengthByteArrayIndexedList.from(bb);
 
         for (int i = 0; i < elements.size(); i++) {
-            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            final long puttedValue = elements.get(i).toByteBuffer().getChar();
             Assert.assertEquals(puttedValue, list.getCharUnsafe(i));
         }
     }

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -101,6 +101,54 @@ public class ByteArrayIndexedListTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArrayIndexedListTestShortUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((short) 0));
+        elements.add(UnsignedByteArrays.from((short) 1));
+        elements.add(UnsignedByteArrays.from((short) 2));
+        elements.add(UnsignedByteArrays.from((short) 3));
+        elements.add(UnsignedByteArrays.from((short) 4));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArrayIndexedList(elements);
+        final ByteArrayIndexedList list =
+                FixedLengthByteArrayIndexedList.from(bb);
+
+        Assert.assertEquals(elements.size(), list.size());
+
+        for (int i = 0; i < elements.size(); ++i) {
+            final long puttedValue = elements.get(i).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getShortUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromFixedLengthByteArrayIndexedListTestCharUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from('a'));
+        elements.add(UnsignedByteArrays.from('b'));
+        elements.add(UnsignedByteArrays.from('c'));
+        elements.add(UnsignedByteArrays.from('d'));
+        elements.add(UnsignedByteArrays.from('e'));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArrayIndexedList(elements);
+        final ByteArrayIndexedList list =
+                FixedLengthByteArrayIndexedList.from(bb);
+
+        Assert.assertEquals(elements.size(), list.size());
+
+        for (int i = 0; i < elements.size(); ++i) {
+            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getCharUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArrayIndexedList(
             final Collection<UnsignedByteArray> elements) throws IOException {
         final com.yandex.yoctodb.util.mutable.impl.FixedLengthByteArrayIndexedList fixedLengthByteArrayIndexedList =

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -183,6 +183,50 @@ public class ByteArrayIndexedListTest {
         }
     }
 
+    @Test
+    public void buildingFromVariableLengthByteArrayIndexedListTestShortUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((short) 0));
+        elements.add(UnsignedByteArrays.from((short) 1));
+        elements.add(UnsignedByteArrays.from((short) 2));
+        elements.add(UnsignedByteArrays.from((short) 3));
+        elements.add(UnsignedByteArrays.from((short) 4));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArrayIndexedLength(elements);
+        final ByteArrayIndexedList list =
+                VariableLengthByteArrayIndexedList.from(bb);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getShortUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArrayIndexedListTestCharUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from('a'));
+        elements.add(UnsignedByteArrays.from('b'));
+        elements.add(UnsignedByteArrays.from('c'));
+        elements.add(UnsignedByteArrays.from('d'));
+        elements.add(UnsignedByteArrays.from('e'));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArrayIndexedLength(elements);
+        final ByteArrayIndexedList list =
+                VariableLengthByteArrayIndexedList.from(bb);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getCharUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromVariableLengthByteArrayIndexedLength(
             final Collection<UnsignedByteArray> elements) throws IOException {
         final com.yandex.yoctodb.util.mutable.impl.VariableLengthByteArrayIndexedList variableLengthByteArrayIndexedList =

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArrayIndexedListTest.java
@@ -149,6 +149,30 @@ public class ByteArrayIndexedListTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArrayIndexedListTestByteUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((byte) 0));
+        elements.add(UnsignedByteArrays.from((byte) 1));
+        elements.add(UnsignedByteArrays.from((byte) 2));
+        elements.add(UnsignedByteArrays.from((byte) 3));
+        elements.add(UnsignedByteArrays.from((byte) 4));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArrayIndexedList(elements);
+        final ByteArrayIndexedList list =
+                FixedLengthByteArrayIndexedList.from(bb);
+
+        Assert.assertEquals(elements.size(), list.size());
+
+        for (int i = 0; i < elements.size(); ++i) {
+            final long puttedValue = elements.get(i).toByteBuffer().get() ^ Byte.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getByteUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArrayIndexedList(
             final Collection<UnsignedByteArray> elements) throws IOException {
         final com.yandex.yoctodb.util.mutable.impl.FixedLengthByteArrayIndexedList fixedLengthByteArrayIndexedList =
@@ -271,6 +295,28 @@ public class ByteArrayIndexedListTest {
         for (int i = 0; i < elements.size(); i++) {
             final long puttedValue = elements.get(i).toByteBuffer().getChar();
             Assert.assertEquals(puttedValue, list.getCharUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArrayIndexedListTestByteUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((byte) 0));
+        elements.add(UnsignedByteArrays.from((byte) -2));
+        elements.add(UnsignedByteArrays.from((byte) 34));
+        elements.add(UnsignedByteArrays.from((byte) 21));
+        elements.add(UnsignedByteArrays.from((byte) 13));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArrayIndexedLength(elements);
+        final ByteArrayIndexedList list =
+                VariableLengthByteArrayIndexedList.from(bb);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().get() ^ Byte.MIN_VALUE;
+            Assert.assertEquals(puttedValue, list.getByteUnsafe(i));
         }
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
@@ -166,6 +166,33 @@ public class ByteArraySortedSetTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArraySortedSetTestByteUnsafe()
+            throws IOException {
+        //unsorted elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((byte) -128));
+        elements.add(UnsignedByteArrays.from((byte) 123));
+        elements.add(UnsignedByteArrays.from((byte) 2));
+        elements.add(UnsignedByteArrays.from((byte) 3));
+        elements.add(UnsignedByteArrays.from((byte) 127));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                FixedLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().get() ^ Byte.MIN_VALUE;
+            assertEquals(puttedValue, ss.getByteUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArraySortedSet(
             final Collection<UnsignedByteArray> items) throws IOException {
         final SortedSet<UnsignedByteArray> elements =
@@ -318,6 +345,33 @@ public class ByteArraySortedSetTest {
         for (int i = 0; i < elements.size(); i++) {
             final long puttedValue = elements.get(i).toByteBuffer().getChar();
             assertEquals(puttedValue, ss.getCharUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArraySortedSetTestByteUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((byte) 0));
+        elements.add(UnsignedByteArrays.from((byte) 1));
+        elements.add(UnsignedByteArrays.from((byte) 2));
+        elements.add(UnsignedByteArrays.from((byte) 3));
+        elements.add(UnsignedByteArrays.from((byte) 4));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                VariableLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().get() ^ Byte.MIN_VALUE;
+            assertEquals(puttedValue, ss.getByteUnsafe(i));
         }
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
@@ -112,6 +112,60 @@ public class ByteArraySortedSetTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArraySortedSetTestShortUnsafe()
+            throws IOException {
+        //unsorted elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((short) 0));
+        elements.add(UnsignedByteArrays.from((short) 1));
+        elements.add(UnsignedByteArrays.from((short) 2));
+        elements.add(UnsignedByteArrays.from((short) 3));
+        elements.add(UnsignedByteArrays.from((short) 4));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                FixedLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+            assertEquals(puttedValue, ss.getShortUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromFixedLengthByteArraySortedSetTestCharUnsafe()
+            throws IOException {
+        //unsorted elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from('a'));
+        elements.add(UnsignedByteArrays.from('b'));
+        elements.add(UnsignedByteArrays.from('c'));
+        elements.add(UnsignedByteArrays.from('d'));
+        elements.add(UnsignedByteArrays.from('e'));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                FixedLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            assertEquals(puttedValue, ss.getCharUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArraySortedSet(
             final Collection<UnsignedByteArray> items) throws IOException {
         final SortedSet<UnsignedByteArray> elements =
@@ -210,6 +264,60 @@ public class ByteArraySortedSetTest {
         for (int i = 0; i < elements.size(); i++) {
             final long puttedValue = elements.get(i).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
             assertEquals(puttedValue, ss.getIntUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArraySortedSetTestShortUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from((short) 0));
+        elements.add(UnsignedByteArrays.from((short) 1));
+        elements.add(UnsignedByteArrays.from((short) 2));
+        elements.add(UnsignedByteArrays.from((short) 3));
+        elements.add(UnsignedByteArrays.from((short) 4));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                VariableLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getShort() ^ Short.MIN_VALUE;
+            assertEquals(puttedValue, ss.getShortUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArraySortedSetTestCharUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from('a'));
+        elements.add(UnsignedByteArrays.from('b'));
+        elements.add(UnsignedByteArrays.from('c'));
+        elements.add(UnsignedByteArrays.from('d'));
+        elements.add(UnsignedByteArrays.from('e'));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                VariableLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            assertEquals(puttedValue, ss.getCharUnsafe(i));
         }
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
@@ -58,6 +58,60 @@ public class ByteArraySortedSetTest {
         }
     }
 
+    @Test
+    public void buildingFromFixedLengthByteArraySortedSetTestLongUnsafe()
+            throws IOException {
+        //unsorted elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0L));
+        elements.add(UnsignedByteArrays.from(1L));
+        elements.add(UnsignedByteArrays.from(2L));
+        elements.add(UnsignedByteArrays.from(3L));
+        elements.add(UnsignedByteArrays.from(4L));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                FixedLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+            assertEquals(puttedValue, ss.getLongUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromFixedLengthByteArraySortedSetTestIntUnsafe()
+            throws IOException {
+        //unsorted elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0));
+        elements.add(UnsignedByteArrays.from(1));
+        elements.add(UnsignedByteArrays.from(2));
+        elements.add(UnsignedByteArrays.from(3));
+        elements.add(UnsignedByteArrays.from(4));
+
+        final Buffer bb =
+                prepareDataFromFixedLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                FixedLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+            assertEquals(puttedValue, ss.getIntUnsafe(i));
+        }
+    }
+
     private Buffer prepareDataFromFixedLengthByteArraySortedSet(
             final Collection<UnsignedByteArray> items) throws IOException {
         final SortedSet<UnsignedByteArray> elements =
@@ -102,6 +156,60 @@ public class ByteArraySortedSetTest {
             assertEquals(
                     elements.get(i).toByteBuffer(),
                     ss.get(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArraySortedSetTestLongUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0L));
+        elements.add(UnsignedByteArrays.from(1L));
+        elements.add(UnsignedByteArrays.from(2L));
+        elements.add(UnsignedByteArrays.from(3L));
+        elements.add(UnsignedByteArrays.from(4L));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                VariableLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getLong() ^ Long.MIN_VALUE;
+            assertEquals(puttedValue, ss.getLongUnsafe(i));
+        }
+    }
+
+    @Test
+    public void buildingFromVariableLengthByteArraySortedSetTestIntUnsafe()
+            throws IOException {
+        //elements
+        final List<UnsignedByteArray> elements = new ArrayList<>();
+        elements.add(UnsignedByteArrays.from(0));
+        elements.add(UnsignedByteArrays.from(1));
+        elements.add(UnsignedByteArrays.from(2));
+        elements.add(UnsignedByteArrays.from(3));
+        elements.add(UnsignedByteArrays.from(4));
+
+        final Buffer bb =
+                prepareDataFromVariableLengthByteArraySortedSet(elements);
+        final ByteArraySortedSet ss =
+                VariableLengthByteArraySortedSet.from(bb);
+
+        assertEquals(elements.size(), ss.size());
+
+        //sorting to compare
+        Collections.sort(elements);
+
+        for (int i = 0; i < elements.size(); i++) {
+            final long puttedValue = elements.get(i).toByteBuffer().getInt() ^ Integer.MIN_VALUE;
+            assertEquals(puttedValue, ss.getIntUnsafe(i));
         }
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/ByteArraySortedSetTest.java
@@ -161,7 +161,7 @@ public class ByteArraySortedSetTest {
         Collections.sort(elements);
 
         for (int i = 0; i < elements.size(); i++) {
-            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            final long puttedValue = elements.get(i).toByteBuffer().getChar();
             assertEquals(puttedValue, ss.getCharUnsafe(i));
         }
     }
@@ -316,7 +316,7 @@ public class ByteArraySortedSetTest {
         Collections.sort(elements);
 
         for (int i = 0; i < elements.size(); i++) {
-            final long puttedValue = elements.get(i).toByteBuffer().getChar() ^ Character.MIN_VALUE;
+            final long puttedValue = elements.get(i).toByteBuffer().getChar();
             assertEquals(puttedValue, ss.getCharUnsafe(i));
         }
     }

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedListTest.java
@@ -56,7 +56,7 @@ public class FoldedByteArrayIndexedListTest {
     }
 
     @Test
-    public void tesShortFolding() throws IOException {
+    public void testShortFolding() throws IOException {
         assertTrue(build(1000).toString().contains(Integer.toString(1000)));
     }
 

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedListTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/FoldedByteArrayIndexedListTest.java
@@ -1,3 +1,13 @@
+/*
+ * (C) YANDEX LLC, 2014-2016
+ *
+ * The Source Code called "YoctoDB" available at
+ * https://github.com/yandex/yoctodb is subject to the terms of the
+ * Mozilla Public License, v. 2.0 (hereinafter referred to as the "License").
+ *
+ * A copy of the License is also available at http://mozilla.org/MPL/2.0/.
+ */
+
 package com.yandex.yoctodb.util.immutable.impl;
 
 import com.yandex.yoctodb.util.UnsignedByteArray;

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSetTest.java
@@ -156,6 +156,26 @@ public class TrieByteArraySortedSetTest {
         trieSet.get(0);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void getLongUnsafe() {
+        trieSet.getLongUnsafe(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getIntUnsafe() {
+        trieSet.getIntUnsafe(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getShortUnsafe() {
+        trieSet.getShortUnsafe(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getCharUnsafe() {
+        trieSet.getCharUnsafe(0);
+    }
+
     @Test
     public void indexOfMutable() {
         for (String q : keys) {

--- a/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSetTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/immutable/impl/TrieByteArraySortedSetTest.java
@@ -176,6 +176,11 @@ public class TrieByteArraySortedSetTest {
         trieSet.getCharUnsafe(0);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void getByteUnsafe() {
+        trieSet.getByteUnsafe(0);
+    }
+
     @Test
     public void indexOfMutable() {
         for (String q : keys) {

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 <configuration>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
-                    <showDeprecation>false</showDeprecation>
+                    <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <fork>true</fork>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 <configuration>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
-                    <showDeprecation>true</showDeprecation>
+                    <showDeprecation>false</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <fork>true</fork>
                 </configuration>


### PR DESCRIPTION
Issue: [Allow unsafe reading fields as primitives #39](https://github.com/yandex/yoctodb/issues/39)