### PR TITLE
Fix test buildV1StoredIndex

### DIFF
--- a/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;

--- a/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
@@ -26,7 +26,7 @@ public class V1StoredIndexTest {
     public void buildV1StoredIndex() {
         final String fieldName = "testFiledName";
         V1StoredIndex index = new V1StoredIndex(fieldName);
-        final TreeMap<Integer, UnsignedByteArray> data = new TreeMap<>(initData());
+        final Map<Integer, UnsignedByteArray> data = initData();
         List<UnsignedByteArray> elements = new ArrayList<>(data.size());
         for(Map.Entry<Integer, UnsignedByteArray> entry : data.entrySet()) {
             index.addDocument(entry.getKey(), Collections.singletonList(entry.getValue()));
@@ -42,7 +42,7 @@ public class V1StoredIndexTest {
     }
 
     private Map<Integer, UnsignedByteArray> initData() {
-        Map<Integer, UnsignedByteArray> data = new HashMap<>();
+        Map<Integer, UnsignedByteArray> data = new TreeMap<>();
         data.put(0, UnsignedByteArrays.from("NEW"));
         data.put(1, UnsignedByteArrays.from("USED"));
         return data;

--- a/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
+++ b/core/src/test/java/com/yandex/yoctodb/util/mutable/stored/V1StoredIndexTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * {@link com.yandex.yoctodb.util.immutable.ByteArrayIndexedList} with fixed size
@@ -25,7 +26,7 @@ public class V1StoredIndexTest {
     public void buildV1StoredIndex() {
         final String fieldName = "testFiledName";
         V1StoredIndex index = new V1StoredIndex(fieldName);
-        final Map<Integer, UnsignedByteArray> data = initData();
+        final TreeMap<Integer, UnsignedByteArray> data = new TreeMap<>(initData());
         List<UnsignedByteArray> elements = new ArrayList<>(data.size());
         for(Map.Entry<Integer, UnsignedByteArray> entry : data.entrySet()) {
             index.addDocument(entry.getKey(), Collections.singletonList(entry.getValue()));


### PR DESCRIPTION
## The Problem

In test `com.yandex.yoctodb.util.mutable.stored.V1StoredIndexTest.buildV1StoredIndex`, a Map iterator is called implicitly. However, according to [Java specification](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html),

> The `Map` interface provides three *collection views*, which allow a map's contents to be viewed as a set of keys, collection of values, or set of key-value mappings. The *order* of a map is defined as the order in which the iterators on the map's collection views return their elements. Some map implementations, like the `TreeMap` class, make specific guarantees as to their order; others, like the `HashMap` class, do not.

The plugin [NonDex](https://github.com/TestingResearchIllinois/NonDex) detects such usages that assumes a determinist order, so that when the iterator's implementation is changed, this test fails without really having a problem. Here are the steps to reproduce the issue:

```
git clone https://github.com/yandex/yoctodb && cd yoctodb
export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
mvn clean install -pl core -am -DskipTests -Dgpg.skip
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl core -Dtest=V1StoredIndexTest#buildV1StoredIndex
```

## The Fix

The specification does guarantee that `TreeMap` has a deterministic iterator. Using that information, casting the `Map` to `TreeMap` can guarantee that the test will yield the same result every time it runs.

After the fix, running the previous procedure will always pass. This ensures that the test case does not fail because of an implementation change for a non-deterministic specification.

Please comment on whether you think this is a viable solution, thanks :)